### PR TITLE
fix: Remove static size for FoListGroup.vue

### DIFF
--- a/packages/core/src/Components/ListGroup/UI/FoListGroup.vue
+++ b/packages/core/src/Components/ListGroup/UI/FoListGroup.vue
@@ -2,12 +2,13 @@
     <component :is="orientation === 'horizontal' ? 'div' : FoFragment"
                class="w-full"
     >
-        <ul class="divide-base-content/25 w-96 divide-y"
+        <ul class="divide-base-content/25 divide-y"
             :class="[
                 orientationClass,
                 flushClass,
                 stripesClass,
                 withoutGuttersClass,
+                orientation !== 'horizontal' && $attrs?.class,
             ]"
         >
             <slot />

--- a/packages/core/src/Shared/Internal/Lib/UseElementClass.ts
+++ b/packages/core/src/Shared/Internal/Lib/UseElementClass.ts
@@ -232,7 +232,7 @@ export function useOrientation(
             },
             'list-group': {
                 horizontal: 'w-full divide-base-content/25 flex flex-col sm:flex-row sm:divide-x sm:divide-y-0 first:*:sm:rounded-s-md first:*:sm:rounded-tr-none last:*:sm:rounded-e-md last:*:sm:rounded-bl-none rtl:divide-x-reverse',
-                vertical:   'w-96',
+                vertical:   '',
             },
             'list-group-item': {
                 horizontal: 'w-full',

--- a/packages/docs/Components/ListGroup/DefaultListGroup.vue
+++ b/packages/docs/Components/ListGroup/DefaultListGroup.vue
@@ -1,5 +1,5 @@
 <template>
-    <FoListGroup>
+    <FoListGroup class="w-96">
         <FoListGroupItem v-for="item in items"
                          :key="item.id"
         >

--- a/packages/docs/Components/ListGroup/FlushedListGroup.vue
+++ b/packages/docs/Components/ListGroup/FlushedListGroup.vue
@@ -1,5 +1,7 @@
 <template>
-    <FoListGroup is-flushed>
+    <FoListGroup class="w-96"
+                 is-flushed
+    >
         <FoListGroupItem v-for="item in items"
                          :key="item.id"
         >

--- a/packages/docs/Components/ListGroup/InvoiceListGroup.vue
+++ b/packages/docs/Components/ListGroup/InvoiceListGroup.vue
@@ -1,5 +1,5 @@
 <template>
-    <FoListGroup>
+    <FoListGroup class="w-96">
         <FoListGroupItem v-for="(item, index) in invoiceItems"
                          :key="item.id"
                          class="justify-between"

--- a/packages/docs/Components/ListGroup/ListGroupWithBadges.vue
+++ b/packages/docs/Components/ListGroup/ListGroupWithBadges.vue
@@ -1,5 +1,5 @@
 <template>
-    <FoListGroup>
+    <FoListGroup class="w-96">
         <FoListGroupItem v-for="item in items"
                          :key="item.id"
                          class="justify-between"

--- a/packages/docs/Components/ListGroup/ListGroupWithCheckbox.vue
+++ b/packages/docs/Components/ListGroup/ListGroupWithCheckbox.vue
@@ -5,7 +5,7 @@
         Select your skills:
     </FoHeading>
 
-    <FoListGroup>
+    <FoListGroup class="w-96">
         <FoListGroupItem v-for="item in skills"
                          :key="item.id"
         >

--- a/packages/docs/Components/ListGroup/ListGroupWithIcons.vue
+++ b/packages/docs/Components/ListGroup/ListGroupWithIcons.vue
@@ -1,5 +1,5 @@
 <template>
-    <FoListGroup>
+    <FoListGroup class="w-96">
         <FoListGroupItem v-for="item in items"
                          :key="item.id"
         >

--- a/packages/docs/Components/ListGroup/ListGroupWithoutGutters.vue
+++ b/packages/docs/Components/ListGroup/ListGroupWithoutGutters.vue
@@ -1,5 +1,6 @@
 <template>
-    <FoListGroup is-flushed
+    <FoListGroup class="w-96"
+                 is-flushed
                  without-gutters
     >
         <FoListGroupItem v-for="item in items"

--- a/packages/docs/Components/ListGroup/StripedListGroup.vue
+++ b/packages/docs/Components/ListGroup/StripedListGroup.vue
@@ -1,5 +1,7 @@
 <template>
-    <FoListGroup is-striped>
+    <FoListGroup class="w-96"
+                 is-striped
+    >
         <FoListGroupItem v-for="item in items"
                          :key="item.id"
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor / Style**
  - Enhanced the styling flexibility of List Group components by removing the default fixed width and conditionally applying additional styling based on orientation.

- **Documentation**
  - Updated the List Group examples to explicitly include width styling, ensuring that the component displays with the intended layout in the demos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->