### PR TITLE
fix: user settings lost after refresh, feat: new themes and possibility to reset config

### DIFF
--- a/packages/core/src/Components/Badge/UI/FoBadge.vue
+++ b/packages/core/src/Components/Badge/UI/FoBadge.vue
@@ -40,7 +40,7 @@ const props = withDefaults(defineProps<BadgeProps>(), {
 
 const componentName: ComponentName = 'FoBadge';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const badgeIcon = usePositionableIcon(
     config,

--- a/packages/core/src/Components/Button/UI/FoButton.vue
+++ b/packages/core/src/Components/Button/UI/FoButton.vue
@@ -57,7 +57,7 @@ const props = withDefaults(defineProps<ButtonProps>(), {
 });
 
 const componentName: ComponentName = 'FoButton';
-const config                       = useFlyonUIVueAppConfig();
+const { config }                   = useFlyonUIVueAppConfig();
 
 const isInJoin: boolean = inject(isInJoinInjectionKey, false);
 

--- a/packages/core/src/Components/Button/UI/FoLoadingButton.vue
+++ b/packages/core/src/Components/Button/UI/FoLoadingButton.vue
@@ -56,7 +56,7 @@ defineSlots<{
     notLoading?: () => VNode[];
 }>();
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const loadingIcon = computed((): Partial<Record<HorizontalPosition, LoadingProps>> => {
     const { position, ...loadingProps } = props.icon;

--- a/packages/core/src/Components/Checkbox/UI/FoCheckbox.vue
+++ b/packages/core/src/Components/Checkbox/UI/FoCheckbox.vue
@@ -65,7 +65,7 @@ const props = withDefaults(defineProps<CheckboxProps>(), {
 
 const componentName: ComponentName = 'FoCheckbox';
 const id                           = useId();
-const config                       = useFlyonUIVueAppConfig();
+const { config }                   = useFlyonUIVueAppConfig();
 
 const isInCheckboxGroup            = inject(isInCheckboxGroupInjectionKey, false);
 

--- a/packages/core/src/Components/InputText/UI/FoInputText.vue
+++ b/packages/core/src/Components/InputText/UI/FoInputText.vue
@@ -114,7 +114,7 @@ const slots = defineSlots<{
 const id                           = useId();
 const componentName: ComponentName = 'FoInputText';
 
-const config            = useFlyonUIVueAppConfig();
+const { config }        = useFlyonUIVueAppConfig();
 const isInJoin: boolean = inject(isInJoinInjectionKey, false);
 
 const input = defineModel<string>({ required: true });

--- a/packages/core/src/Components/Link/UI/FoLink.vue
+++ b/packages/core/src/Components/Link/UI/FoLink.vue
@@ -20,7 +20,7 @@ import { computed, inject }                    from 'vue';
 
 const props = defineProps<LinkProps>();
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const isInMenuItem = inject(isInMenuItemInjectionKey, false);
 

--- a/packages/core/src/Components/Loading/UI/FoLoading.vue
+++ b/packages/core/src/Components/Loading/UI/FoLoading.vue
@@ -22,7 +22,7 @@ const props = withDefaults(defineProps<LoadingProps>(), {
 
 const componentName: ComponentName = 'FoLoading';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const animationClass = computed(() => {
     const icons: Record<Animation, string> = {

--- a/packages/core/src/Components/Menu/UI/FoMenu.vue
+++ b/packages/core/src/Components/Menu/UI/FoMenu.vue
@@ -29,7 +29,7 @@ provide(menuTextPropsInjectionKey, computed(() => (
 
 const componentName: ComponentName = 'FoMenu';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const [
     orientationClass,

--- a/packages/core/src/Components/Navbar/UI/FoNavbarHamburgerMenuToggler.vue
+++ b/packages/core/src/Components/Navbar/UI/FoNavbarHamburgerMenuToggler.vue
@@ -7,12 +7,10 @@
                 @click.prevent="isCollapsed = !isCollapsed"
         >
             <FoIcon v-if="isCollapsed"
-                    class="size-4"
                     icon="tabler:menu-2"
             />
 
             <FoIcon v-else
-                    class="size-4"
                     icon="tabler:x"
             />
         </button>

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -52,7 +52,7 @@ const selectedOption = defineModel<K | null>({ required: true });
 
 const componentName: ComponentName = 'FoSelect';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const [
     floatingLabelClass,

--- a/packages/core/src/Components/Textarea/UI/FoTextarea.vue
+++ b/packages/core/src/Components/Textarea/UI/FoTextarea.vue
@@ -83,7 +83,7 @@ const props = withDefaults(defineProps<TextareaProps>(), {
 const id                           = useId();
 const componentName: ComponentName = 'FoTextarea';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const input = defineModel<string>({ required: true });
 

--- a/packages/core/src/Components/ThemeController/Types/ThemeController.ts
+++ b/packages/core/src/Components/ThemeController/Types/ThemeController.ts
@@ -1,6 +1,17 @@
 import type { UseColorModeOptions } from '@vueuse/core';
 
-export type FlyonUITheme = 'light' | 'dark' | 'gourmet' | 'corporate' | 'luxury' | 'soft' | string;
+export type FlyonUITheme = 'light'
+    | 'dark'
+    | 'gourmet'
+    | 'corporate'
+    | 'ghibli'
+    | 'luxury'
+    | 'mintlify'
+    | 'shadcn'
+    | 'slack'
+    | 'soft'
+    | 'valorant'
+    | string;
 
 export type FlyonUIThemeModes = Record<FlyonUITheme, FlyonUITheme>;
 

--- a/packages/core/src/Components/ThemeController/UI/FoSelectThemeController.vue
+++ b/packages/core/src/Components/ThemeController/UI/FoSelectThemeController.vue
@@ -23,8 +23,13 @@ const props = withDefaults(defineProps<ThemeControllerProps & Omit<SelectProps<F
             dark:      'dark',
             gourmet:   'gourmet',
             corporate: 'corporate',
+            ghibli:    'ghibli',
             luxury:    'luxury',
+            mintlify:  'mintlify',
+            shadcn:    'shadcn',
+            slack:     'slack',
             soft:      'soft',
+            valorant:  'valorant',
         };
     },
 });

--- a/packages/core/src/Components/Tooltip/UI/FoTooltip.vue
+++ b/packages/core/src/Components/Tooltip/UI/FoTooltip.vue
@@ -41,7 +41,7 @@ const props = withDefaults(defineProps<TooltipProps>(), {
 
 const componentName: ComponentName = 'FoTooltip';
 
-const config = useFlyonUIVueAppConfig();
+const { config } = useFlyonUIVueAppConfig();
 
 const isPopover = inject(tooltipAsPopover, false);
 

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
@@ -1,7 +1,7 @@
 import type { FlyonUIVueAppConfig, FlyonUIVueAppDefaultConfig } from '@/Shared/UseFlyonUIVueAppConfig';
 import type { App, FunctionPlugin }                             from 'vue';
 import { useFlyonUIVueAppConfigInjectionKey }                   from '@/Shared/UseFlyonUIVueAppConfig';
-import { useStorage }                                           from '@vueuse/core';
+import { useLocalStorage }                                      from '@vueuse/core';
 import deepMerge                                                from 'deepmerge';
 
 export const flyonUIVueAppDefaultConfig: FlyonUIVueAppDefaultConfig = {
@@ -25,21 +25,17 @@ export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: Ap
     const global     = deepMerge(flyonUIVueAppDefaultConfig.global, userConfig.global ?? {});
     const components = deepMerge(flyonUIVueAppDefaultConfig.components ?? {}, userConfig.components ?? {});
 
-    const initialConfig = { global, components };
+    // todo: remove when this will be merged https://github.com/vueuse/vueuse/pull/4784
+    const initialConfig = (): FlyonUIVueAppDefaultConfig => structuredClone({ global, components });
 
-    if (globalThis.localStorage === undefined) {
-        return;
-    }
-
-    const config = useStorage<FlyonUIVueAppDefaultConfig>(
+    const config = useLocalStorage<FlyonUIVueAppDefaultConfig>(
         'flyonui-vue-config',
         initialConfig,
-        globalThis.localStorage,
         { mergeDefaults: true },
     );
 
     const resetConfig = (): void => {
-        config.value = initialConfig;
+        config.value = initialConfig();
     };
 
     app.provide(

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
@@ -21,19 +21,25 @@ export const flyonUIVueAppDefaultConfig: FlyonUIVueAppDefaultConfig = {
     },
 };
 
-export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: App, config: FlyonUIVueAppConfig) => {
-    const global     = deepMerge(flyonUIVueAppDefaultConfig.global, config.global ?? {});
-    const components = deepMerge(flyonUIVueAppDefaultConfig.components ?? {}, config.components ?? {});
+export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: App, userConfig: FlyonUIVueAppConfig) => {
+    const global     = deepMerge(flyonUIVueAppDefaultConfig.global, userConfig.global ?? {});
+    const components = deepMerge(flyonUIVueAppDefaultConfig.components ?? {}, userConfig.components ?? {});
 
-    const data = useStorage<FlyonUIVueAppDefaultConfig>(
+    const initialConfig = { global, components };
+
+    const config = useStorage<FlyonUIVueAppDefaultConfig>(
         'flyonui-vue-config',
-        { global, components },
+        initialConfig,
         localStorage,
         { mergeDefaults: true },
     );
 
+    const resetConfig = (): void => {
+        config.value = initialConfig;
+    };
+
     app.provide(
         useFlyonUIVueAppConfigInjectionKey,
-        data,
+        { config, resetConfig },
     );
 };

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
@@ -27,10 +27,14 @@ export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: Ap
 
     const initialConfig = { global, components };
 
+    if (globalThis.localStorage === undefined) {
+        return;
+    }
+
     const config = useStorage<FlyonUIVueAppDefaultConfig>(
         'flyonui-vue-config',
         initialConfig,
-        localStorage,
+        globalThis.localStorage,
         { mergeDefaults: true },
     );
 

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
@@ -1,8 +1,8 @@
 import type { FlyonUIVueAppConfig, FlyonUIVueAppDefaultConfig } from '@/Shared/UseFlyonUIVueAppConfig';
 import type { App, FunctionPlugin }                             from 'vue';
 import { useFlyonUIVueAppConfigInjectionKey }                   from '@/Shared/UseFlyonUIVueAppConfig';
+import { useStorage }                                           from '@vueuse/core';
 import deepMerge                                                from 'deepmerge';
-import { ref }                                                  from 'vue';
 
 export const flyonUIVueAppDefaultConfig: FlyonUIVueAppDefaultConfig = {
     global: {
@@ -25,8 +25,15 @@ export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: Ap
     const global     = deepMerge(flyonUIVueAppDefaultConfig.global, config.global ?? {});
     const components = deepMerge(flyonUIVueAppDefaultConfig.components ?? {}, config.components ?? {});
 
+    const data = useStorage<FlyonUIVueAppDefaultConfig>(
+        'flyonui-vue-config',
+        { global, components },
+        localStorage,
+        { mergeDefaults: true },
+    );
+
     app.provide(
         useFlyonUIVueAppConfigInjectionKey,
-        ref<FlyonUIVueAppDefaultConfig>({ global, components }),
+        data,
     );
 };

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/UseFlyonUIVueAppConfig.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/UseFlyonUIVueAppConfig.ts
@@ -10,12 +10,14 @@ interface FlyonUIVueAppInjectedConfig {
 
 export const useFlyonUIVueAppConfigInjectionKey: InjectionKey<FlyonUIVueAppInjectedConfig> = Symbol('Create FlyonUI Vue App');
 
-export function useFlyonUIVueAppConfig(): FlyonUIVueAppInjectedConfig {
-    const defaultConfig = ref<FlyonUIVueAppDefaultConfig>({ ...flyonUIVueAppDefaultConfig });
+const initialConfig = ref<FlyonUIVueAppDefaultConfig>({ ...flyonUIVueAppDefaultConfig });
 
+export function useFlyonUIVueAppConfig(): FlyonUIVueAppInjectedConfig {
     const defaultValue: FlyonUIVueAppInjectedConfig = {
-        config:      defaultConfig,
-        resetConfig: () => defaultConfig.value = flyonUIVueAppDefaultConfig,
+        config:      initialConfig,
+        resetConfig: () => {
+            initialConfig.value = { ...flyonUIVueAppDefaultConfig };
+        },
     };
 
     return inject(

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/UseFlyonUIVueAppConfig.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/UseFlyonUIVueAppConfig.ts
@@ -3,8 +3,23 @@ import type { InjectionKey, Ref }          from 'vue';
 import { flyonUIVueAppDefaultConfig }      from '@/Shared/UseFlyonUIVueAppConfig';
 import { inject, ref }                     from 'vue';
 
-export const useFlyonUIVueAppConfigInjectionKey: InjectionKey<Ref<FlyonUIVueAppDefaultConfig>> = Symbol('Create FlyonUI Vue App');
+interface FlyonUIVueAppInjectedConfig {
+    config:      Ref<FlyonUIVueAppDefaultConfig>;
+    resetConfig: () => void;
+}
 
-export function useFlyonUIVueAppConfig(): Ref<FlyonUIVueAppDefaultConfig> {
-    return inject(useFlyonUIVueAppConfigInjectionKey, ref({ ...flyonUIVueAppDefaultConfig }));
+export const useFlyonUIVueAppConfigInjectionKey: InjectionKey<FlyonUIVueAppInjectedConfig> = Symbol('Create FlyonUI Vue App');
+
+export function useFlyonUIVueAppConfig(): FlyonUIVueAppInjectedConfig {
+    const defaultConfig = ref<FlyonUIVueAppDefaultConfig>({ ...flyonUIVueAppDefaultConfig });
+
+    const defaultValue: FlyonUIVueAppInjectedConfig = {
+        config:      defaultConfig,
+        resetConfig: () => defaultConfig.value = flyonUIVueAppDefaultConfig,
+    };
+
+    return inject(
+        useFlyonUIVueAppConfigInjectionKey,
+        defaultValue,
+    );
 }

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue
@@ -68,8 +68,11 @@ import SizeSettings
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/SizeSettings.vue';
 import ThemeSettings
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/ThemeSettings.vue';
-import { flyonUIVueAppDefaultConfig, FoListGroup, useFlyonUIVueAppConfigInjectionKey } from 'flyonui-vue';
-import { inject, ref }                                                                 from 'vue';
+import {
+    FoListGroup,
+    useFlyonUIVueAppConfig,
+} from 'flyonui-vue';
+import { ref } from 'vue';
 
 interface Props {
     themeStorageKey: string;
@@ -77,7 +80,7 @@ interface Props {
 
 defineProps<Props>();
 
-const config = inject(useFlyonUIVueAppConfigInjectionKey, ref(flyonUIVueAppDefaultConfig));
+const { config } = useFlyonUIVueAppConfig();
 
 const showGlobalSettings = ref<boolean>(true);
 </script>

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsHeader.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsHeader.vue
@@ -20,7 +20,6 @@
                   icon="ix:hard-reset"
                   shape="circle"
                   size="small"
-                  :is-disabled="!canResetConfig"
                   @click.prevent="resetConfig()"
         />
     </FoListGroupItem>
@@ -28,14 +27,8 @@
 
 <script setup lang="ts">
 import { FoButton, FoIcon, FoListGroupItem, FoSwap, useFlyonUIVueAppConfig } from 'flyonui-vue';
-import { ref, watch }                                                        from 'vue';
 
 const show = defineModel<boolean>({ required: true });
 
-const { config, resetConfig } = useFlyonUIVueAppConfig();
-const canResetConfig          = ref<boolean>(false);
-
-watch(config, () => {
-    canResetConfig.value = true;
-}, { deep: true });
+const { resetConfig } = useFlyonUIVueAppConfig();
 </script>

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsHeader.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsHeader.vue
@@ -8,21 +8,34 @@
                 animation="rotation"
         >
             <template #on>
-                <FoIcon icon="tabler:circle-minus"
-                        size="extraLarge"
-                />
+                <FoIcon icon="tabler:circle-minus" />
             </template>
             <template #off>
-                <FoIcon icon="tabler:circle-plus"
-                        size="extraLarge"
-                />
+                <FoIcon icon="tabler:circle-plus" />
             </template>
         </FoSwap>
+
+        <FoButton class="ms-auto"
+                  color="error"
+                  icon="ix:hard-reset"
+                  shape="circle"
+                  size="small"
+                  :is-disabled="!canResetConfig"
+                  @click.prevent="resetConfig()"
+        />
     </FoListGroupItem>
 </template>
 
 <script setup lang="ts">
-import { FoIcon, FoListGroupItem, FoSwap } from 'flyonui-vue';
+import { FoButton, FoIcon, FoListGroupItem, FoSwap, useFlyonUIVueAppConfig } from 'flyonui-vue';
+import { ref, watch }                                                        from 'vue';
 
 const show = defineModel<boolean>({ required: true });
+
+const { config, resetConfig } = useFlyonUIVueAppConfig();
+const canResetConfig          = ref<boolean>(false);
+
+watch(config, () => {
+    canResetConfig.value = true;
+}, { deep: true });
 </script>

--- a/packages/docs/.vitepress/theme/Components/Navbar.vue
+++ b/packages/docs/.vitepress/theme/Components/Navbar.vue
@@ -41,11 +41,11 @@
 </template>
 
 <script setup lang="ts">
-import type { NavbarLink }   from 'flyonui-vue';
+import type { FlyonUITheme, NavbarLink } from 'flyonui-vue';
 import ConfigurationSettings
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue';
 import { loadIcons }                                                            from '@iconify/vue';
-import { useColorMode, useLocalStorage }                                        from '@vueuse/core';
+import { useColorMode, useStorage }                                             from '@vueuse/core';
 import { FoButton, FoLink, FoNavbar, FoNavbarBrand, FoPopover, FoSocialButton } from 'flyonui-vue';
 import { useRouter, withBase }                                                  from 'vitepress';
 import { computed, onMounted, ref }                                             from 'vue';
@@ -70,9 +70,19 @@ onMounted(() => {
      * The theme selector will be shown only on click, in order to allow the automatic theme selection from local
      * storage on first load, it must be fetched and set according to the user one.
      */
-    const initialValue = useLocalStorage(themeStorageKey, 'dark');
-    const theme        = useColorMode({ initialValue, attribute: 'data-theme' });
-    theme.value = initialValue.value;
+    const initialValue = useStorage<FlyonUITheme>(
+        themeStorageKey,
+        'dark',
+        localStorage,
+        { mergeDefaults: true },
+    );
+
+    useColorMode({
+        initialValue,
+        attribute:     'data-theme',
+        mergeDefaults: true,
+        storageKey:    themeStorageKey,
+    });
 
     loadIcons([
         'radix-icons:dimensions',

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -23,8 +23,8 @@ import PopoverDocs                              from '@/Overlays/Popover/Popover
 import TooltipDocs                              from '@/Overlays/Tooltip/TooltipDocs.vue';
 import Playground                               from '@/Playground/Playground.vue';
 
-import { FoSelectThemeController, vMask } from 'flyonui-vue';
-import DefaultTheme                       from 'vitepress/theme';
+import { createFlyonUIVueApp, FoSelectThemeController, vMask } from 'flyonui-vue';
+import DefaultTheme                                            from 'vitepress/theme';
 import './index.css';
 
 export default {
@@ -49,7 +49,7 @@ export default {
         //     },
         // };
 
-        // app.use(createFlyonUIVueApp, createFlyonUIVueAppOptions);
+        app.use(createFlyonUIVueApp, {});
 
         registerDocComponents(app, [
             { name: 'LinkDocs', instance: LinkDocs },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five new selectable themes: Ghibli, Mintlify, Shadcn, Slack, and Valorant.
  - Introduced a reset button in configuration settings to restore default settings instantly.

- **Improvements**
  - Theme and configuration settings now persist automatically using local storage.
  - Enhanced theme initialization and management for a more consistent user experience.

- **Style**
  - Simplified icon sizing in navigation and configuration components for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->