### PR TITLE
feat: Add possibility to have label type globally configurable

### DIFF
--- a/packages/core/src/Components/InputText/Types/InputText.ts
+++ b/packages/core/src/Components/InputText/Types/InputText.ts
@@ -9,7 +9,7 @@ import type { Validity }                   from '@/Shared/UseValidity';
 
 export interface InputTextProps extends MaybeStringId, Disableable, Validity, Sizable, WithConfigurableHelperText, WithConfigurableIcon {
     type?:         'text' | 'email';
-    label?:        InputLabel;
+    label?:        string | InputLabel;
     placeholder?:  string;
     shape?:        Extract<Shape, 'rounded' | 'pilled'>;
     withoutFocus?: boolean;

--- a/packages/core/src/Components/InputText/UI/FoInputText.vue
+++ b/packages/core/src/Components/InputText/UI/FoInputText.vue
@@ -77,8 +77,8 @@
 </template>
 
 <script setup lang="ts">
-import type { InputTextProps }        from '@/Components/InputText';
-import type { InputLabel, LabelType } from '@/Components/Label';
+import type { InputTextProps } from '@/Components/InputText';
+import type { LabelType }      from '@/Components/Label';
 
 import type { IconSize }                           from '@/Shared';
 import type { ComponentName }                      from '@/Shared/Utils/Internal';
@@ -89,9 +89,9 @@ import { FoIcon }                                  from '@/Components/Icon';
 import { usePositionableIcon }                     from '@/Components/Icon/Internal';
 import { isInJoinInjectionKey, useJoinItem }       from '@/Components/Join/Internal';
 
-import { FoLabel }          from '@/Components/Label/Internal';
-import { useFloatingLabel } from '@/Shared/UseFloatingLabel/Internal';
+import { FoLabel, useLabel } from '@/Components/Label/Internal';
 
+import { useFloatingLabel }        from '@/Shared/UseFloatingLabel/Internal';
 import { useFlyonUIVueAppConfig }  from '@/Shared/UseFlyonUIVueAppConfig';
 import { useShape }                from '@/Shared/UseShape/Internal';
 import { useSize }                 from '@/Shared/UseSize/Internal';
@@ -134,17 +134,11 @@ const inputHelperText = usePositionableHelperText(
     () => props.helperText,
 );
 
-const defaultLabel = computed((): Required<InputLabel> | undefined => {
-    if (props.label === undefined) {
-        return undefined;
-    }
-
-    return {
-        text:     props.label.text,
-        type:     props.label.type === undefined ? 'text' : props.label.type,
-        isHidden: props.label.isHidden ?? false,
-    };
-});
+const defaultLabel = useLabel(
+    config,
+    componentName,
+    () => props.label,
+);
 
 const hasIcon = computed(() => {
     return inputIcon.value?.left !== undefined || inputIcon.value?.right !== undefined;

--- a/packages/core/src/Components/Label/Internal/Lib/UseLabel.ts
+++ b/packages/core/src/Components/Label/Internal/Lib/UseLabel.ts
@@ -1,0 +1,38 @@
+import type { InputLabel, LabelType }              from '@/Components';
+import type { ConfigurableLabelComponentName }     from '@/Components/Label/Internal/Types';
+import type { FlyonUIVueAppDefaultConfig }         from '@/Shared';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { computed, toValue }                       from 'vue';
+
+export function useLabel<T extends LabelType>(
+    config: Ref<FlyonUIVueAppDefaultConfig>,
+    componentName: MaybeRefOrGetter<ConfigurableLabelComponentName>,
+    label: MaybeRefOrGetter<string | InputLabel<T> | undefined>,
+): ComputedRef<Required<InputLabel<T>> | undefined> {
+    return computed((): Required<InputLabel<T>> | undefined => {
+        const configurableLabel = toValue(label);
+
+        if (configurableLabel === undefined) {
+            return undefined;
+        }
+
+        const [labelType, globalLabelType] = [
+            config.value.components?.[toValue(componentName)]?.labelType,
+            config.value.global.labelType,
+        ];
+
+        if (typeof configurableLabel === 'string') {
+            return {
+                text:     configurableLabel,
+                type:     (labelType ?? globalLabelType) as T,
+                isHidden: false,
+            };
+        }
+
+        return {
+            text:     configurableLabel.text,
+            type:     (configurableLabel.type === undefined ? 'text' : configurableLabel.type) as T,
+            isHidden: configurableLabel.isHidden ?? false,
+        };
+    });
+}

--- a/packages/core/src/Components/Label/Internal/Lib/index.ts
+++ b/packages/core/src/Components/Label/Internal/Lib/index.ts
@@ -1,0 +1,1 @@
+export * from '@/Components/Label/Internal/Lib/UseLabel';

--- a/packages/core/src/Components/Label/Internal/Types/Label.ts
+++ b/packages/core/src/Components/Label/Internal/Types/Label.ts
@@ -1,5 +1,8 @@
 import type { LabelType }                  from '@/Components/Label';
 import type { FloatingLabelComponentName } from '@/Shared/UseFloatingLabel';
+import type { ComponentName }              from '@/Shared/Utils/Internal';
+
+export type ConfigurableLabelComponentName = Extract<ComponentName, 'FoInputText' | 'FoSelect' | 'FoTextarea'>;
 
 export interface LabelProps {
     componentName?: FloatingLabelComponentName;

--- a/packages/core/src/Components/Label/Internal/index.ts
+++ b/packages/core/src/Components/Label/Internal/index.ts
@@ -1,1 +1,2 @@
+export * from '@/Components/Label/Internal/Lib';
 export * from '@/Components/Label/Internal/UI';

--- a/packages/core/src/Components/Select/Types/Select.ts
+++ b/packages/core/src/Components/Select/Types/Select.ts
@@ -8,7 +8,7 @@ export interface SelectOption<T extends number | string = number> extends Id<T>,
 }
 
 export interface SelectProps<T extends string | number = number, K extends SelectOption<T> = SelectOption<T>> extends Sizable {
-    label: {
+    label?: string | {
         text:  string;
         type?: Exclude<LabelType, 'inline'>; // When undefined the label will be a text by default
     };

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -9,10 +9,10 @@
                 :class="[sizeClass]"
                 aria-label="select"
         >
-            <option v-if="isTextLabel"
+            <option v-if="defaultLabel?.type === 'text'"
                     :value="null"
             >
-                {{ label.text }}
+                {{ defaultLabel.text }}
             </option>
 
             <option v-for="option in options"
@@ -24,12 +24,12 @@
             </option>
         </select>
 
-        <FoLabel v-if="label.type !== undefined"
+        <FoLabel v-if="defaultLabel && defaultLabel.type !== 'text'"
                  :for="id"
                  :component-name="componentName"
-                 :type="label.type"
+                 :type="defaultLabel.type"
         >
-            {{ label.text }}
+            {{ defaultLabel.text }}
         </FoLabel>
     </div>
 </template>
@@ -37,11 +37,11 @@
 <script setup lang="ts" generic="T extends string | number, K extends SelectOption<T>">
 import type { SelectOption, SelectProps } from '@/Components/Select';
 import type { ComponentName }             from '@/Shared/Utils/Internal';
-import { FoLabel }                        from '@/Components/Label/Internal';
+import { FoLabel, useLabel }              from '@/Components/Label/Internal';
 import { useFloatingLabel }               from '@/Shared/UseFloatingLabel/Internal';
 import { useFlyonUIVueAppConfig }         from '@/Shared/UseFlyonUIVueAppConfig';
 import { useSize }                        from '@/Shared/UseSize/Internal';
-import { computed, useId, watchEffect }   from 'vue';
+import { useId, watchEffect }             from 'vue';
 
 const props = defineProps<SelectProps<T, K>>();
 
@@ -53,17 +53,19 @@ const componentName: ComponentName = 'FoSelect';
 
 const { config } = useFlyonUIVueAppConfig();
 
+const defaultLabel = useLabel(
+    config,
+    componentName,
+    () => props.label,
+);
+
 const [
     floatingLabelClass,
     sizeClass,
 ] = [
-    useFloatingLabel(componentName, () => props.label.type),
+    useFloatingLabel(componentName, () => defaultLabel.value?.type),
     useSize(config, componentName, () => props.size),
 ];
-
-const isTextLabel = computed(() => {
-    return [undefined, 'text'].includes(props.label.type);
-});
 
 watchEffect(() => {
     if (props.options.length === 0) {
@@ -73,7 +75,7 @@ watchEffect(() => {
     /**
      * when no option is selected and the label is not the null option, the selected one will be the first.
      */
-    if (selectedOption.value === null && isTextLabel.value === false) {
+    if (selectedOption.value === null && defaultLabel.value?.type !== 'text') {
         selectedOption.value = props.options[0];
     }
 });

--- a/packages/core/src/Components/Textarea/Types/Textarea.ts
+++ b/packages/core/src/Components/Textarea/Types/Textarea.ts
@@ -6,12 +6,12 @@ import type { Sizable }                    from '@/Shared/UseSize';
 import type { Disableable }                from '@/Shared/UseState';
 import type { Validity }                   from '@/Shared/UseValidity';
 
-type TextareaLabelType = Exclude<LabelType, 'inline'>;
+export type TextareaLabelType = Exclude<LabelType, 'inline'>;
 
 export type TextareaLabel = InputLabel<TextareaLabelType>;
 
 export interface TextareaProps extends MaybeStringId, Disableable, Validity, Sizable, WithConfigurableHelperText, WithConfigurableIcon {
     placeholder?: string;
-    label?:       TextareaLabel;
+    label?:       string | InputLabel<TextareaLabelType>;
     isReadonly?:  boolean;
 }

--- a/packages/core/src/Components/Textarea/UI/FoTextarea.vue
+++ b/packages/core/src/Components/Textarea/UI/FoTextarea.vue
@@ -57,14 +57,14 @@
 </template>
 
 <script setup lang="ts">
-import type { TextareaLabel, TextareaProps }       from '@/Components/Textarea';
+import type { TextareaLabelType, TextareaProps }   from '@/Components/Textarea';
 import type { IconSize }                           from '@/Shared';
 import type { ComponentName }                      from '@/Shared/Utils/Internal';
 import { FoFragment }                              from '@/Components/Fragment/Internal';
 import { FoHelperText, usePositionableHelperText } from '@/Components/HelperText/Internal';
 import { FoIcon }                                  from '@/Components/Icon';
 import { usePositionableIcon }                     from '@/Components/Icon/Internal';
-import { FoLabel }                                 from '@/Components/Label/Internal';
+import { FoLabel, useLabel }                       from '@/Components/Label/Internal';
 import { useFloatingLabel }                        from '@/Shared/UseFloatingLabel/Internal';
 import { useFlyonUIVueAppConfig }                  from '@/Shared/UseFlyonUIVueAppConfig';
 import { useSize }                                 from '@/Shared/UseSize/Internal';
@@ -102,17 +102,11 @@ const textareaHelperText = usePositionableHelperText(
     () => props.helperText,
 );
 
-const defaultLabel = computed((): Required<TextareaLabel> | undefined => {
-    if (props.label === undefined) {
-        return undefined;
-    }
-
-    return {
-        text:     props.label.text,
-        type:     props.label.type === undefined ? 'text' : props.label.type,
-        isHidden: props.label.isHidden ?? false,
-    };
-});
+const defaultLabel = useLabel<TextareaLabelType>(
+    config,
+    componentName,
+    () => props.label,
+);
 
 const [
     floatingClass,

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
@@ -23,7 +23,12 @@ export interface FlyonUIVueAppDefaultConfig {
     components?: FlyonUIVueAppComponentsConfig;
 }
 
-type LabelTypeConfig = Exclude<LabelType, 'inline'>;
+export type GlobalLabelType = Exclude<LabelType, 'inline'>;
+
+interface LabelTypeComponentConfig {
+    labelType?: GlobalLabelType;
+}
+
 type ShapeConfig = Extract<Shape, 'rounded' | 'pilled'>;
 
 interface HorizontalIconPositionConfig {
@@ -46,7 +51,7 @@ export interface FlyonUIVueAppGlobalConfig {
     // textColor:          Color | undefined;
     direction:          Direction;
     horizontalPosition: HorizontalPositionGlobalConfig;
-    labelType:          LabelTypeConfig;
+    labelType:          GlobalLabelType;
     orientation:        Orientation;
     preset:             Preset;
     shape:              ShapeConfig;
@@ -54,7 +59,7 @@ export interface FlyonUIVueAppGlobalConfig {
 }
 
 type ConfigurableProps<MaybeProps extends object> = Prettify<
-    PickIfExists<MaybeProps, 'color' | 'horizontalPosition' | 'preset' | 'shape' | 'size'>
+    PickIfExists<MaybeProps, 'color' | 'horizontalPosition' | 'labelType' | 'preset' | 'shape' | 'size'>
 >;
 
 export interface ConfigurableComponentProps {
@@ -62,14 +67,22 @@ export interface ConfigurableComponentProps {
     FoButton:    ConfigurableProps<ButtonProps & HorizontalPositionComponentConfig<HorizontalIconPositionConfig>>;
     FoCheckbox:  ConfigurableProps<CheckboxProps>;
     FoIcon:      ConfigurableProps<IconProps>;
-    FoInputText: ConfigurableProps<InputTextProps & HorizontalPositionComponentConfig<HorizontalPositionGlobalConfig>>;
-    FoLink:      ConfigurableProps<LinkProps>;
-    FoLoading:   ConfigurableProps<LoadingProps>;
-    FoMenu:      ConfigurableProps<MenuProps>;
-    FoRadio:     ConfigurableProps<ButtonProps>; // todo: temporary
-    FoSelect:    ConfigurableProps<SelectProps>;
-    FoTextarea:  ConfigurableProps<TextareaProps & HorizontalPositionComponentConfig<HorizontalPositionGlobalConfig>>;
-    FoTooltip:   ConfigurableProps<TooltipProps>;
+    FoInputText: ConfigurableProps<
+        InputTextProps
+        & HorizontalPositionComponentConfig<HorizontalPositionGlobalConfig>
+        & LabelTypeComponentConfig
+    >;
+    FoLink:     ConfigurableProps<LinkProps>;
+    FoLoading:  ConfigurableProps<LoadingProps>;
+    FoMenu:     ConfigurableProps<MenuProps>;
+    FoRadio:    ConfigurableProps<ButtonProps>; // todo: temporary
+    FoSelect:   ConfigurableProps<SelectProps> & LabelTypeComponentConfig;
+    FoTextarea: ConfigurableProps<
+        TextareaProps
+        & HorizontalPositionComponentConfig<HorizontalPositionGlobalConfig>
+        & LabelTypeComponentConfig
+    >;
+    FoTooltip: ConfigurableProps<TooltipProps>;
 }
 
 export type FlyonUIVueAppComponentsConfig = {

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue
@@ -49,6 +49,10 @@
             <ConfigurationSettingsItem icon="fluent:shapes-20-regular">
                 <ShapeSettings v-model="config.global.shape" />
             </ConfigurationSettingsItem>
+
+            <ConfigurationSettingsItem icon="quill:label">
+                <LabelTypeSettings v-model="config.global.labelType" />
+            </ConfigurationSettingsItem>
         </template>
     </FoListGroup>
 </template>
@@ -60,6 +64,7 @@ import ConfigurationSettingsHeader
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsHeader.vue';
 import ConfigurationSettingsItem
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettingsItem.vue';
+import LabelTypeSettings from '@/.vitepress/theme/Components/ConfigurationSettings/UI/LabelTypeSettings.vue';
 import PresetSettings
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/PresetSettings.vue';
 import ShapeSettings

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/LabelTypeSettings.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/LabelTypeSettings.vue
@@ -1,0 +1,19 @@
+<template>
+    <FoButton v-for="labelType in labelTypes"
+              :key="labelType"
+              :color="labelType === selectedLabelType ? 'warning' : 'primary'"
+              size="extraSmall"
+              @click="selectedLabelType = labelType"
+    >
+        {{ labelType }}
+    </FoButton>
+</template>
+
+<script setup lang="ts">
+import type { GlobalLabelType } from 'flyonui-vue';
+import { FoButton }             from 'flyonui-vue';
+
+const selectedLabelType = defineModel<GlobalLabelType>({ required: true });
+
+const labelTypes: GlobalLabelType[] = ['text', 'floating'];
+</script>

--- a/packages/docs/Forms/InputText/InputTextWithLabelAndHelperText.vue
+++ b/packages/docs/Forms/InputText/InputTextWithLabelAndHelperText.vue
@@ -1,6 +1,6 @@
 <template>
     <FoInputText v-model="input"
-                 :label="{ text: 'Full Name' }"
+                 label="Full Name"
                  placeholder="John Doe"
                  helper-text="Please write your full name"
     />

--- a/packages/docs/Forms/Select/DefaultSelect.vue
+++ b/packages/docs/Forms/Select/DefaultSelect.vue
@@ -1,6 +1,6 @@
 <template>
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              label="Pick your favorite Movie"
               :options="options"
     />
 </template>

--- a/packages/docs/Forms/Textarea/TextareaWithLabelAndPlaceholder.vue
+++ b/packages/docs/Forms/Textarea/TextareaWithLabelAndPlaceholder.vue
@@ -1,6 +1,11 @@
 <template>
     <FoTextarea v-model="input"
-                :label="{ text: 'Your bio' }"
+                label="Your bio"
+                placeholder="Hello!!!"
+    />
+
+    <FoTextarea v-model="input"
+                :label="{ text: 'Your bio', type: 'floating' }"
                 placeholder="Hello!!!"
     />
 </template>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@stackblitz/sdk": "^1.11.0",
         "@vueuse/core": "^13.0.0",
-        "flyonui": "^2.1.0",
+        "flyonui": "^2.2.0",
         "flyonui-vue": "workspace:*",
         "highlight.js": "^10.7.3",
         "tailwindcss": "^4.0.17",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -39,7 +39,7 @@
         "type-check": "vue-tsc --noEmit -p tsconfig.json"
     },
     "dependencies": {
-        "flyonui": "^2.1.0",
+        "flyonui": "^2.2.0",
         "flyonui-vue": "workspace:*"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5002,7 +5002,7 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     "@vue/tsconfig": "npm:^0.7.0"
     "@vueuse/core": "npm:^13.0.0"
-    flyonui: "npm:^2.1.0"
+    flyonui: "npm:^2.2.0"
     flyonui-vue: "workspace:*"
     highlight.js: "npm:^10.7.3"
     jsdom: "npm:^26.0.0"
@@ -5065,7 +5065,7 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     "@vue/tsconfig": "npm:^0.7.0"
     concurrently: "npm:^9.1.2"
-    flyonui: "npm:^2.1.0"
+    flyonui: "npm:^2.2.0"
     flyonui-vue: "workspace:*"
     jsdom: "npm:^26.0.0"
     tsc-alias: "npm:^1.8.11"
@@ -5076,12 +5076,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"flyonui@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "flyonui@npm:2.1.0"
+"flyonui@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "flyonui@npm:2.2.0"
   dependencies:
     "@floating-ui/dom": "npm:^1.6.13"
-  checksum: 10c0/459bb2529eb0f39cd62354a78229c6b0487bf2ef7ca3d1f7aa35d3bc83588eac0cae763189ec7c9edbeb18b15ddb6fefed76fb117855ab568942bbcee350ed83
+  checksum: 10c0/240f219503cc574def233d3b3870e7daa9945b94295b5b649aab53cae60783e6b5ff3f1c269087c0ef963da36924dad73a204b0d1994354f897e24049b088ac7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global setting in the documentation UI to configure the default label type for form components.
  - Introduced a new settings component for selecting label styles.

- **Enhancements**
  - Input, select, and textarea components now accept label props as either a simple string or an object, providing more flexibility.
  - Centralized and improved label handling for form components.

- **Documentation**
  - Updated examples to use the simplified string label prop.
  - Added documentation for the new label type configuration option.

- **Chores**
  - Updated dependencies to use the latest version of the UI library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->