### PR TITLE
Add staging docs build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,9 @@ jobs:
             -   name: Build with VitePress
                 env:
                     GENERATE_BUILD_SIZE_VISUALIZER: true
-                run: yarn build
+                run: |
+                    yarn build
+                    yarn build:docs:staging
 
             -   name: Upload artifact
                 uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "dependency-upgrade": "npx yarn-upgrade-all",
         "dev": "yarn concurrently \"yarn workspace flyonui-vue dev:vue\" \"yarn workspace flyonui-vue-docs dev\"",
         "build": "yarn workspaces foreach -Apt run build",
+        "build:docs:staging": "yarn workspace flyonui-vue-docs build:staging",
         "lint": "yarn workspaces foreach -Apt run lint",
         "test": "vitest run",
         "test-coverage": "vitest run --coverage",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,6 +11,7 @@
         "dev": "vitepress",
         "preview": "vitepress preview",
         "build": "yarn type-check && vitepress build && cp -r assets/* ./.vitepress/dist/assets/",
+        "build:staging": "vitepress build --base=/flyonui-vue/staging/ --outDir .vitepress/dist/staging && cp -r assets/* ./.vitepress/dist/staging/assets/",
         "lint": "eslint . --fix",
         "test": "vitest run",
         "test:e2e": "npx playwright test EndToEnd",


### PR DESCRIPTION
## Summary
- add a `build:staging` docs script for deploying under `/staging`
- expose a root `build:docs:staging` script
- run the staging build in the deployment workflow

## Testing
- `yarn test` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.6.0/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_684560cfa02c83328c4d3677bb8a37d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated staging build process for the documentation, generating output with a custom base path and isolated directory.
- **Chores**
  - Updated build scripts and deployment workflow to include the new staging documentation build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->