### PR TITLE
refactor: Disallow some presets from global settings

### DIFF
--- a/packages/core/src/Components/Badge/Types/Badge.ts
+++ b/packages/core/src/Components/Badge/Types/Badge.ts
@@ -5,7 +5,7 @@ import type { Shapeable }            from '@/Shared/UseShape';
 import type { Size }                 from '@/Shared/UseSize';
 
 export interface BadgeProps extends Colorable, Shapeable, WithConfigurableIcon {
-    preset?:        Preset;
+    preset?:        Exclude<Preset, 'gradient' | 'text'>;
     size?:          Size;
     isDismissible?: boolean;
 }

--- a/packages/core/src/Components/Button/Types/Button.ts
+++ b/packages/core/src/Components/Button/Types/Button.ts
@@ -21,8 +21,7 @@ export interface ButtonProps extends MaybeStringId, Colorable, Disableable, Resp
 }
 
 export type Social = 'Facebook' | 'Twitter' | 'Linkedin' | 'Github';
-
-type SocialButtonPreset = Extract<Preset, 'solid' | 'soft' | 'outline'>;
+export type SocialButtonPreset = Extract<Preset, 'solid' | 'soft' | 'outline'>;
 
 export interface SocialButtonProps extends Omit<ButtonProps, 'preset'> {
     social:  Social;

--- a/packages/core/src/Components/Textarea/Types/Textarea.ts
+++ b/packages/core/src/Components/Textarea/Types/Textarea.ts
@@ -12,6 +12,6 @@ export type TextareaLabel = InputLabel<TextareaLabelType>;
 
 export interface TextareaProps extends MaybeStringId, Disableable, Validity, Sizable, WithConfigurableHelperText, WithConfigurableIcon {
     placeholder?: string;
-    label?:       string | InputLabel<TextareaLabelType>;
+    label?:       string | TextareaLabel;
     isReadonly?:  boolean;
 }

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
@@ -24,12 +24,12 @@ export interface FlyonUIVueAppDefaultConfig {
 }
 
 export type GlobalLabelType = Exclude<LabelType, 'inline'>;
+export type GlobalPresetType = Exclude<Preset, 'gradient' | 'text'>;
+export type GlobalShapeType = Extract<Shape, 'rounded' | 'pilled'>;
 
 interface LabelTypeComponentConfig {
     labelType?: GlobalLabelType;
 }
-
-type ShapeConfig = Extract<Shape, 'rounded' | 'pilled'>;
 
 interface HorizontalIconPositionConfig {
     icon: HorizontalPosition;
@@ -53,8 +53,8 @@ export interface FlyonUIVueAppGlobalConfig {
     horizontalPosition: HorizontalPositionGlobalConfig;
     labelType:          GlobalLabelType;
     orientation:        Orientation;
-    preset:             Preset;
-    shape:              ShapeConfig;
+    preset:             GlobalPresetType;
+    shape:              GlobalShapeType;
     size:               Size;
 }
 

--- a/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/PresetSettings.vue
+++ b/packages/docs/.vitepress/theme/Components/ConfigurationSettings/UI/PresetSettings.vue
@@ -10,10 +10,10 @@
 </template>
 
 <script setup lang="ts">
-import type { Preset } from 'flyonui-vue';
-import { FoButton }    from 'flyonui-vue';
+import type { GlobalPresetType } from 'flyonui-vue';
+import { FoButton }              from 'flyonui-vue';
 
-const selectedPreset = defineModel<Preset>({ required: true });
+const selectedPreset = defineModel<GlobalPresetType>({ required: true });
 
-const presets: Preset[] = ['dash', 'text', 'soft', 'outline', 'gradient', 'solid'];
+const presets: GlobalPresetType[] = ['solid', 'soft', 'outline', 'dash'];
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Restricted available preset options for badges and global configuration, removing support for 'gradient' and 'text' presets.
  - Updated global configuration types to clarify and limit preset and shape options.
  - Simplified type usage for textarea labels.
  - Made the SocialButtonPreset type available for external use.
  - Updated documentation UI to reflect the revised preset options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->