### PR TITLE
refactor: UseSelectedOption.ts to handle nullable and not nullable options differently with the same composable

### DIFF
--- a/packages/core/src/Components/Select/Internal/Lib/IsSelectOptionGroup.ts
+++ b/packages/core/src/Components/Select/Internal/Lib/IsSelectOptionGroup.ts
@@ -1,8 +1,8 @@
-import type { SelectOptionGroup, SelectOptionType } from '@/Components';
+import type { SelectOption, SelectOptionGroup, SelectOptionType } from '@/Components';
 
-export function isSelectOptionGroup<T extends string | number>(
-    option: SelectOptionType<T>,
-): option is SelectOptionGroup<T> {
+export function isSelectOptionGroup<T extends string | number, K extends SelectOption<T>>(
+    option: SelectOptionType<T, K>,
+): option is SelectOptionGroup<T, K> {
     if ('options' in option === false) {
         return false;
     }

--- a/packages/core/src/Components/Select/Internal/Lib/OnEmptyOptions.ts
+++ b/packages/core/src/Components/Select/Internal/Lib/OnEmptyOptions.ts
@@ -1,10 +1,10 @@
-import type { SelectOptionType } from '@/Components';
-import type { MaybeRefOrGetter } from 'vue';
-import { useArrayLength }        from '@/Shared/Utils/Internal';
-import { watch }                 from 'vue';
+import type { SelectOption, SelectOptionType } from '@/Components';
+import type { MaybeRefOrGetter }               from 'vue';
+import { useArrayLength }                      from '@/Shared/Utils/Internal';
+import { watch }                               from 'vue';
 
-export function onEmptyOptions<T extends number | string>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T>>[]>,
+export function onEmptyOptions<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
 ): void {
     watch(useArrayLength(options), (length) => {
         if (length === 0) {

--- a/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
+++ b/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
@@ -1,10 +1,19 @@
-import type { SelectOption, SelectOptionType }            from '@/Components/Select';
-import type { MaybeRefOrGetter, Ref, UnwrapRef }          from 'vue';
-import { isSelectOptionGroup }                            from '@/Components/Select/Internal';
-import { useIdentifiable }                                from '@/Shared/UseIdentifiable/Internal';
-import { isReadonly, isRef, toRef, toValue, watchEffect } from 'vue';
+import type { SelectOption, SelectOptionType }                 from '@/Components/Select';
+import type { MaybeRefOrGetter, Ref, UnwrapRef }               from 'vue';
+import { isSelectOptionGroup }                                 from '@/Components/Select/Internal';
+import { useIdentifiable }                                     from '@/Shared/UseIdentifiable/Internal';
+import { isReadonly, isRef, ref, toValue, watch, watchEffect } from 'vue';
 
-type UseSelectedOptionReturn<T extends number | string> = Ref<UnwrapRef<SelectOption<T> | null>>;
+export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+    id: MaybeRefOrGetter<T | null>,
+): Ref<K | null>;
+
+export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+    id: MaybeRefOrGetter<T>,
+    allowNull: false,
+): Ref<K>;
 
 /**
  * Retrieves the select option of a select field.
@@ -12,15 +21,97 @@ type UseSelectedOptionReturn<T extends number | string> = Ref<UnwrapRef<SelectOp
  * @param options
  * @param id The initial id of the option to retrieve, if it is a writable ref, the id will automatically be
  *           overridden with the selected option id when a new one is selected.
- * @return UseSelectedOptionReturn<T>
+ * @param allowNull true if there can be a non-selected option, false otherwise.
  */
-export function useSelectedOption<T extends number | string = number>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T>>[]>,
+export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+    id: MaybeRefOrGetter<T | null> | MaybeRefOrGetter<T>,
+    allowNull: boolean = true,
+): Ref<K | null> | Ref<K> {
+    return isNullAllowed(id, allowNull)
+        ? useSelectedNullableOption(options, id)
+        : useSelectedNonNullableOption(options, id);
+}
+
+export function useSelectedNullableOption<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
     id: MaybeRefOrGetter<T | null>,
-): UseSelectedOptionReturn<T> {
+): Ref<K | null> {
+    const flatOptions = getFlatOptions(options);
+
+    const selectedOption = useIdentifiable<'id', T, K>(flatOptions, id, 'id');
+
+    const option = ref<K | null>(null);
+
+    watch(selectedOption, () => option.value = selectedOption.value, { immediate: true });
+
+    // todo: this behaviour should be documented
+    watchEffect(() => {
+        if (isReadonly(id) === false && isRef(id)) {
+            (id as Ref<T | null>).value = option.value?.id ?? null;
+        }
+    });
+
+    return option as Ref<K | null>;
+}
+
+export function useSelectedNonNullableOption<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+    id: MaybeRefOrGetter<T>,
+): Ref<K> {
+    const flatOptions = getFlatOptions(options);
+
+    const selectedOption = useIdentifiable<'id', T, K>(flatOptions, id, 'id');
+
+    const option = ref<K | null>(null);
+
+    watch(
+        selectedOption,
+        () => {
+            option.value = getSelectedOptionIfNotNull(selectedOption).value;
+        },
+        { immediate: true },
+    );
+
+    // todo: this behaviour should be documented
+    watchEffect(() => {
+        if (isReadonly(id) === false && isRef(id)) {
+            (id as Ref<UnwrapRef<T>>).value = getSelectedOptionIfNotNull(option).value.id;
+        }
+    });
+
+    return getSelectedOptionIfNotNull(option) as Ref<K>;
+}
+
+function isNullAllowed<T extends number | string>(
+    id: MaybeRefOrGetter<T | null> | MaybeRefOrGetter<T>,
+    allowNull: boolean,
+): id is MaybeRefOrGetter<T | null> {
+    return allowNull;
+}
+
+function guardAgainstSelectedOption<T extends string | number>(
+    selectedOption: Ref<SelectOption<T> | null>,
+): asserts selectedOption is Ref<SelectOption<T>> {
+    if (selectedOption.value === null) {
+        throw new Error('Selected option cannot be null.');
+    }
+}
+
+function getSelectedOptionIfNotNull<T extends string | number, K extends SelectOption<T>>(
+    selectedOption: Ref<K | null>,
+): Ref<K> {
+    guardAgainstSelectedOption(selectedOption);
+
+    return selectedOption;
+}
+
+function getFlatOptions<T extends number | string, K extends SelectOption<T>>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+): K[] {
     const maybeGroupedOptions = toValue(options).map(toValue);
 
-    let flatOptions: SelectOption<T>[] = [];
+    let flatOptions: K[] = [];
 
     for (const maybeGroupedOption of maybeGroupedOptions) {
         if (isSelectOptionGroup(maybeGroupedOption)) {
@@ -30,14 +121,5 @@ export function useSelectedOption<T extends number | string = number>(
         }
     }
 
-    const selectedOption = toRef(useIdentifiable<'id', T, SelectOption<T>>(flatOptions, id, 'id').value);
-
-    // todo: this behaviour should be documented
-    watchEffect(() => {
-        if (isReadonly(id) === false && isRef(id)) {
-            (id as Ref<T | null>).value = (selectedOption.value?.id ?? null) as T | null;
-        }
-    });
-
-    return selectedOption;
+    return flatOptions;
 }

--- a/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
+++ b/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
@@ -45,7 +45,6 @@ export function useSelectedNullableOption<T extends number | string, K extends S
 
     watch(selectedOption, () => option.value = selectedOption.value, { immediate: true });
 
-    // todo: this behaviour should be documented
     watchEffect(() => {
         if (isReadonly(id) === false && isRef(id)) {
             (id as Ref<T | null>).value = option.value?.id ?? null;
@@ -73,7 +72,6 @@ export function useSelectedNonNullableOption<T extends number | string, K extend
         { immediate: true },
     );
 
-    // todo: this behaviour should be documented
     watchEffect(() => {
         if (isReadonly(id) === false && isRef(id)) {
             (id as Ref<UnwrapRef<T>>).value = getSelectedOptionIfNotNull(option).value.id;

--- a/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
+++ b/packages/core/src/Components/Select/Lib/UseSelectedOption.ts
@@ -67,18 +67,18 @@ export function useSelectedNonNullableOption<T extends number | string, K extend
     watch(
         selectedOption,
         () => {
-            option.value = getSelectedOptionIfNotNull(selectedOption).value;
+            option.value = getSelectedOptionIfExists(id, selectedOption).value;
         },
         { immediate: true },
     );
 
     watchEffect(() => {
         if (isReadonly(id) === false && isRef(id)) {
-            (id as Ref<UnwrapRef<T>>).value = getSelectedOptionIfNotNull(option).value.id;
+            (id as Ref<UnwrapRef<T>>).value = getSelectedOptionIfExists(id, option).value.id;
         }
     });
 
-    return getSelectedOptionIfNotNull(option) as Ref<K>;
+    return getSelectedOptionIfExists(id, option) as Ref<K>;
 }
 
 function isNullAllowed<T extends number | string>(
@@ -88,18 +88,20 @@ function isNullAllowed<T extends number | string>(
     return allowNull;
 }
 
-function guardAgainstSelectedOption<T extends string | number>(
+function guardAgainstNonExistingSelectedOption<T extends string | number>(
+    id: MaybeRefOrGetter<T>,
     selectedOption: Ref<SelectOption<T> | null>,
 ): asserts selectedOption is Ref<SelectOption<T>> {
     if (selectedOption.value === null) {
-        throw new Error('Selected option cannot be null.');
+        throw new Error(`Selected option ${toValue(id)} does not exist.`);
     }
 }
 
-function getSelectedOptionIfNotNull<T extends string | number, K extends SelectOption<T>>(
+function getSelectedOptionIfExists<T extends string | number, K extends SelectOption<T>>(
+    id: MaybeRefOrGetter<T>,
     selectedOption: Ref<K | null>,
 ): Ref<K> {
-    guardAgainstSelectedOption(selectedOption);
+    guardAgainstNonExistingSelectedOption(id, selectedOption);
 
     return selectedOption;
 }

--- a/packages/core/src/Components/Select/Types/Select.ts
+++ b/packages/core/src/Components/Select/Types/Select.ts
@@ -1,4 +1,4 @@
-import type { LabelType }                from '@/Components/Label';
+import type { InputLabel, LabelType }    from '@/Components/Label';
 import type { Shape, Sizable, Validity } from '@/Shared';
 import type { Id, MaybeStringId }        from '@/Shared/UseIdentifiable';
 import type { Disableable }              from '@/Shared/UseState';
@@ -7,28 +7,39 @@ export interface SelectOption<T extends number | string = number> extends Id<T>,
     readonly text: string;
 }
 
-export interface SelectOptionGroup<T extends number | string = number> {
+export interface SelectOptionGroup<T extends number | string = number, K extends SelectOption<T> = SelectOption<T>> {
     label:   string;
-    options: SelectOption<T>[];
-}
-
-export type SelectOptionType<T extends number | string = number> = SelectOption<T> | SelectOptionGroup<T>;
-
-interface BaseSelectProps<T extends string | number, K extends SelectOptionType<T>> extends MaybeStringId, Disableable, Validity {
-    shape?:  Extract<Shape, 'rounded' | 'pilled'>;
     options: K[];
 }
 
-export interface SelectProps<T extends string | number = number, K extends SelectOptionType<T> = SelectOption<T>> extends BaseSelectProps<T, K>, Sizable {
-    label?: string | {
-        text:  string;
-        type?: Exclude<LabelType, 'inline'>; // When undefined the label will be a text by default, todo: option
-    };
+export type SelectOptionType<
+    T extends number | string = number,
+    K extends SelectOption<T> = SelectOption<T>,
+> = K | SelectOptionGroup<T, K>;
+
+interface BaseSelectProps<
+    T extends string | number,
+    K extends SelectOption<T>,
+    V extends SelectOptionType<T, K>,
+> extends MaybeStringId, Disableable, Validity {
+    shape?:  Extract<Shape, 'rounded' | 'pilled'>;
+    options: V[];
+}
+
+export interface SelectProps<
+    T extends string | number = number,
+    K extends SelectOption<T> = SelectOption<T>,
+    V extends SelectOptionType<T, K> = SelectOptionType<T, K>,
+> extends BaseSelectProps<T, K, V>, Sizable {
+    label?: string | InputLabel<Exclude<LabelType, 'inline'>>; // todo: option label
 }
 
 export type DatalistOption<T extends number | string> = Omit<SelectOption<T>, 'isDisabled'>;
 
-export interface DatalistProps<T extends string | number = number, K extends DatalistOption<T> = DatalistOption<T>> extends BaseSelectProps<T, K> {
+export interface DatalistProps<
+    T extends string | number = number,
+    K extends DatalistOption<T> = DatalistOption<T>,
+> extends BaseSelectProps<T, K, K> {
     label?:       string;
     placeholder?: string;
 }

--- a/packages/core/src/Components/Select/UI/FoDatalist.vue
+++ b/packages/core/src/Components/Select/UI/FoDatalist.vue
@@ -4,7 +4,7 @@
             {{ label }}
         </FoLabel>
 
-        <FoInputText v-model="input"
+        <FoInputText v-model.null="input"
                      :placeholder="placeholder"
                      :shape="shape"
                      :list="id"
@@ -42,6 +42,12 @@ const id = useId(() => props.id);
 const input = computed({
     get: (): string | null => selectedOption.value?.text ?? null,
     set: (newOptionText: string | null) => {
+        if (newOptionText === null) {
+            selectedOption.value = null;
+
+            return;
+        }
+
         const newOption = props.options.find((option: K): boolean => option.text === newOptionText);
 
         if (newOption === undefined) {

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -1,5 +1,5 @@
 <template>
-    <!--    todo: some features are missing  -->
+    <!--    todo: missing hidden label, multiple options  -->
     <component :is="floatingLabelClass === '' ? FoFragment : 'div'"
                v-if="options.length"
                :class="floatingLabelClass"
@@ -47,20 +47,20 @@
     </component>
 </template>
 
-<script setup lang="ts" generic="T extends string | number, K extends SelectOptionType<T>">
-import type { SelectOption, SelectOptionType, SelectProps } from '@/Components/Select';
-import type { ComponentName }                               from '@/Shared/Utils/Internal';
-import { FoFragment }                                       from '@/Components/Fragment/Internal';
-import { FoLabel, useLabel }                                from '@/Components/Label/Internal';
-import { isSelectOptionGroup }                              from '@/Components/Select/Internal';
-import { onEmptyOptions }                                   from '@/Components/Select/Internal/Lib/OnEmptyOptions.ts';
-import FoSelectOption                                       from '@/Components/Select/Internal/UI/FoSelectOption.vue';
-import { useFloatingLabel }                                 from '@/Shared/UseFloatingLabel/Internal';
-import { useFlyonUIVueAppConfig }                           from '@/Shared/UseFlyonUIVueAppConfig';
-import { useShape }                                         from '@/Shared/UseShape/Internal';
-import { useSize }                                          from '@/Shared/UseSize/Internal';
-import { useValidity }                                      from '@/Shared/UseValidity/Internal';
-import { useId, watchEffect }                               from 'vue';
+<script setup lang="ts" generic="T extends string | number, K extends SelectOption<T>">
+import type { SelectOption, SelectProps } from '@/Components/Select';
+import type { ComponentName }             from '@/Shared/Utils/Internal';
+import { FoFragment }                     from '@/Components/Fragment/Internal';
+import { FoLabel, useLabel }              from '@/Components/Label/Internal';
+import { isSelectOptionGroup }            from '@/Components/Select/Internal';
+import { onEmptyOptions }                 from '@/Components/Select/Internal/Lib/OnEmptyOptions.ts';
+import FoSelectOption                     from '@/Components/Select/Internal/UI/FoSelectOption.vue';
+import { useFloatingLabel }               from '@/Shared/UseFloatingLabel/Internal';
+import { useFlyonUIVueAppConfig }         from '@/Shared/UseFlyonUIVueAppConfig';
+import { useShape }                       from '@/Shared/UseShape/Internal';
+import { useSize }                        from '@/Shared/UseSize/Internal';
+import { useValidity }                    from '@/Shared/UseValidity/Internal';
+import { useId, watchEffect }             from 'vue';
 
 const props = withDefaults(defineProps<SelectProps<T, K>>(), {
     isDisabled: undefined,
@@ -98,6 +98,8 @@ onEmptyOptions(() => props.options);
 watchEffect(() => {
     /**
      * when no option is selected and the label is not the null option, the selected one will be the first.
+     * So that in case the developer is using the useSelectedOption composable where allowNull is true, but there is no
+     * way to automatically select the null option, it will still get one option back that is the first one.
      */
     if (selectedOption.value === null && defaultLabel.value?.type !== 'text') {
         const option = props.options[0];

--- a/packages/core/src/Components/ThemeController/UI/FoSelectThemeController.vue
+++ b/packages/core/src/Components/ThemeController/UI/FoSelectThemeController.vue
@@ -7,12 +7,12 @@
 </template>
 
 <script setup lang="ts">
-import type { SelectOption, SelectProps } from '@/Components/Select';
-
+import type { SelectProps }                        from '@/Components/Select';
 import type { FlyonUITheme, ThemeControllerProps } from '@/Components/ThemeController';
-import { FoSelect, useSelectedOption }             from '@/Components/Select';
-import { useArrayMap, useColorMode }               from '@vueuse/core';
-import { computed, onMounted, toValue }            from 'vue';
+
+import { FoSelect, useSelectedOption } from '@/Components/Select';
+import { useArrayMap, useColorMode }   from '@vueuse/core';
+import { onMounted, toValue }          from 'vue';
 
 const props = withDefaults(defineProps<ThemeControllerProps & Omit<SelectProps<FlyonUITheme>, 'label' | 'options'>>(), {
     initialValue: 'dark',
@@ -34,21 +34,12 @@ const props = withDefaults(defineProps<ThemeControllerProps & Omit<SelectProps<F
     },
 });
 
-type ThemeOption = SelectOption<FlyonUITheme>;
-
 const themeOptions = useArrayMap(() => Object.values(props.modes), (mode: FlyonUITheme) => ({
     id:   mode,
     text: mode,
 }));
 
-const theme = useColorMode<FlyonUITheme>(props);
-
-const selectedTheme = computed({
-    get: (): ThemeOption => useSelectedOption(themeOptions, theme.value).value ?? themeOptions.value[0],
-    set: (newSelectedTheme: ThemeOption): void => {
-        theme.value = newSelectedTheme.text;
-    },
-});
+const selectedTheme = useSelectedOption(themeOptions, useColorMode<FlyonUITheme>(props));
 
 onMounted(() => {
     if (toValue(props.initialValue) in props.modes === false) {

--- a/packages/core/src/Shared/UseIdentifiable/Internal/Lib/UseIdentifiable.ts
+++ b/packages/core/src/Shared/UseIdentifiable/Internal/Lib/UseIdentifiable.ts
@@ -24,10 +24,6 @@ export function useIdentifiable<
             (identifiable: Identifiable<Name, Value>) => identifiable[toValue(key)] === _id,
         ).value ?? null;
 
-        if (identifiable === null) {
-            console.warn(`Id "${_id}" not found.`);
-        }
-
         return identifiable;
     });
 }

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -40,6 +40,8 @@
 
 ### Datalist <Badge type="warning" text="Unreleased" />
 
+When the input field is empty the selected option will automatically be null.
+
 <SelectDocs section="datalist" />
 
 ### Optgroup <Badge type="warning" text="Unreleased" />
@@ -52,7 +54,8 @@
 
 The `useSelectedOption` composables can take as second argument a `MaybeRefOrGetter<number|string>`, in most of the cases
 the id of the selected option might come from an object ref or an id ref, in that case passing the writable ref
-containing the id will automatically update it.
+containing the id will automatically update it, instead if you do not pass a writable ref, it will be considered only as 
+the initial selected value for the component and the selected option will be the only one to be updated.
 
 <SelectDocs section="ref-usage" />
 

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -31,6 +31,7 @@
 [//]: # (### Label and helper text)
 
 [//]: # ()
+
 [//]: # (<SelectDocs section="with-label-and-helper-text" />)
 
 ### Disabled <Badge type="warning" text="Unreleased" />
@@ -44,4 +45,14 @@
 ### Optgroup <Badge type="warning" text="Unreleased" />
 
 <SelectDocs section="optgroup" />
+
+## Advanced usage <Badge type="warning" text="Unreleased" />
+
+### Ref usage <Badge type="warning" text="Unreleased" />
+
+The `useSelectedOption` composables can take as second argument a `MaybeRefOrGetter<number|string>`, in most of the cases
+the id of the selected option might come from an object ref or an id ref, in that case passing the writable ref
+containing the id will automatically update it.
+
+<SelectDocs section="ref-usage" />
 

--- a/packages/docs/Forms/Select/DisabledSelect.vue
+++ b/packages/docs/Forms/Select/DisabledSelect.vue
@@ -26,5 +26,5 @@ const options = ref<SelectOption[]>([
 ]);
 
 const selectedOption         = useSelectedOption(options, null);
-const selectedOptionFloating = useSelectedOption(options, null);
+const selectedOptionFloating = useSelectedOption(options, options.value[0].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectDocs.vue
+++ b/packages/docs/Forms/Select/SelectDocs.vue
@@ -60,6 +60,12 @@
                  :code="SelectWithOptgroupRaw"
                  :component="SelectWithOptgroup"
     />
+
+    <CodeSnippet v-else-if="section === 'ref-usage'"
+                 id="ref-usage"
+                 :code="SelectRefUsageRaw"
+                 :component="SelectRefUsage"
+    />
 </template>
 
 <script setup lang="ts">
@@ -77,6 +83,8 @@ import SelectFloatingLabel             from '@/Forms/Select/SelectFloatingLabel.
 import SelectFloatingLabelRaw          from '@/Forms/Select/SelectFloatingLabel.vue?raw';
 import SelectFloatingLabelSize         from '@/Forms/Select/SelectFloatingLabelSize.vue';
 import SelectFloatingLabelSizeRaw      from '@/Forms/Select/SelectFloatingLabelSize.vue?raw';
+import SelectRefUsage                  from '@/Forms/Select/SelectRefUsage.vue';
+import SelectRefUsageRaw               from '@/Forms/Select/SelectRefUsage.vue?raw';
 import SelectShape                     from '@/Forms/Select/SelectShape.vue';
 import SelectShapeRaw                  from '@/Forms/Select/SelectShape.vue?raw';
 import SelectValidationState           from '@/Forms/Select/SelectValidationState.vue';
@@ -96,7 +104,8 @@ interface Props {
         | 'with-label-and-helper-text'
         | 'disabled'
         | 'datalist'
-        | 'optgroup';
+        | 'optgroup'
+        | 'ref-usage';
 }
 
 defineProps<Props>();

--- a/packages/docs/Forms/Select/SelectFloatingLabel.vue
+++ b/packages/docs/Forms/Select/SelectFloatingLabel.vue
@@ -18,5 +18,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption(options, options.value[1].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectFloatingLabelSize.vue
+++ b/packages/docs/Forms/Select/SelectFloatingLabelSize.vue
@@ -42,5 +42,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption(options, options.value[0].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectRefUsage.vue
+++ b/packages/docs/Forms/Select/SelectRefUsage.vue
@@ -1,0 +1,48 @@
+<template>
+    <FoSelect v-model="favoriteMovie"
+              label="Pick your favorite Movie"
+              :options="movies"
+    />
+
+    <FoSelect v-model="favoriteSeries"
+              label="Pick your favorite Series"
+              :options="series"
+    />
+</template>
+
+<script setup lang="ts">
+import type { SelectOption }           from 'flyonui-vue';
+import { FoSelect, useSelectedOption } from 'flyonui-vue';
+import { ref, toRef }                  from 'vue';
+
+const movies = ref<SelectOption[]>([
+    { id: 1, text: 'The Godfather' },
+    { id: 2, text: 'The Shawshank Redemption' },
+    { id: 3, text: 'Pulp Fiction' },
+    { id: 4, text: 'The Dark Knight' },
+    { id: 5, text: `Schindler's List` },
+]);
+
+const favoriteMovieId = ref<number | null>(null);
+const favoriteMovie   = useSelectedOption(movies, favoriteMovieId);
+
+const series = ref<SelectOption[]>([
+    { id: 1, text: 'Breaking Bad' },
+    { id: 2, text: 'Game of Thrones' },
+    { id: 3, text: 'The Sopranos' },
+    { id: 4, text: 'Stranger Things' },
+    { id: 5, text: 'The Wire' },
+    { id: 6, text: 'Friends' },
+    { id: 7, text: 'The Office' },
+]);
+
+const user = ref<{
+    name:             string;
+    favoriteSeriesId: number | null;
+}>({
+    name:             'Michael',
+    favoriteSeriesId: null,
+});
+
+const favoriteSeries = useSelectedOption(series, toRef(user.value, 'favoriteSeriesId'));
+</script>

--- a/packages/docs/Forms/Select/SelectShape.vue
+++ b/packages/docs/Forms/Select/SelectShape.vue
@@ -36,5 +36,5 @@ const options = ref<SelectOption[]>([
 ]);
 
 const selectedOption         = useSelectedOption(options, null);
-const selectedOptionFloating = useSelectedOption(options, null);
+const selectedOptionFloating = useSelectedOption(options, options.value[0].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectValidationState.vue
+++ b/packages/docs/Forms/Select/SelectValidationState.vue
@@ -38,5 +38,5 @@ const options = ref<SelectOption[]>([
 ]);
 
 const selectedOption         = useSelectedOption(options, null);
-const selectedOptionFloating = useSelectedOption(options, null);
+const selectedOptionFloating = useSelectedOption(options, options.value[0].id, false);
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced usage examples and documentation for select components, including how to bind selected options using refs.
  * Introduced a new example component demonstrating ref-based selection.

* **Enhancements**
  * Improved type safety and flexibility for select options, groups, and props, allowing more precise option structures.
  * Enhanced `useSelectedOption` composable with overloads for nullable and non-nullable selections, better error handling, and improved reactive synchronization.
  * Select and datalist components now better support null values and initial selection states.
  * Updated documentation to clarify behavior when input is empty and to describe advanced usage patterns.

* **Bug Fixes**
  * Selection components now properly handle and propagate null values when inputs are cleared.

* **Documentation**
  * Expanded Select component documentation with advanced usage and ref-based examples.

* **Style**
  * Improved code formatting and comments for clarity.

* **Chores**
  * Removed unnecessary warnings and simplified some internal logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->