### PR TITLE
feat: Add Helper text and icons to FoSelect

### DIFF
--- a/packages/core/src/Components/HelperText/Types/PositionableHelperText.ts
+++ b/packages/core/src/Components/HelperText/Types/PositionableHelperText.ts
@@ -1,7 +1,7 @@
 import type { HorizontalPosition } from '@/Shared/Utils';
 import type { ComponentName }      from '@/Shared/Utils/Internal';
 
-export type PositionableHelperTextComponentName = Extract<ComponentName, 'FoInputText' | 'FoTextarea'>;
+export type PositionableHelperTextComponentName = Extract<ComponentName, 'FoInputText' | 'FoSelect' | 'FoTextarea'>;
 
 export type ConfigurableHelperText = string | PositionableHelperText;
 

--- a/packages/core/src/Components/Label/Internal/UI/FoLabel.vue
+++ b/packages/core/src/Components/Label/Internal/UI/FoLabel.vue
@@ -41,7 +41,7 @@ const labelClass = computed(() => {
             inline:   'label-text my-auto p-0',
         },
         FoSelect: {
-            text:     '',
+            text:     'label-text',
             floating: 'select-floating-label',
             inline:   '',
         },

--- a/packages/core/src/Components/Select/Types/Select.ts
+++ b/packages/core/src/Components/Select/Types/Select.ts
@@ -32,6 +32,7 @@ export interface SelectProps<
     K extends SelectOption<T> = SelectOption<T>,
     V extends SelectOptionType<T, K> = SelectOptionType<T, K>,
 > extends BaseSelectProps<T, K, V>, Sizable {
+    icon?:  string;
     label?: string | InputLabel;
 }
 

--- a/packages/core/src/Components/Select/Types/Select.ts
+++ b/packages/core/src/Components/Select/Types/Select.ts
@@ -1,7 +1,8 @@
-import type { InputLabel, LabelType }    from '@/Components/Label';
-import type { Shape, Sizable, Validity } from '@/Shared';
-import type { Id, MaybeStringId }        from '@/Shared/UseIdentifiable';
-import type { Disableable }              from '@/Shared/UseState';
+import type { WithConfigurableHelperText } from '@/Components/HelperText';
+import type { InputLabel }                 from '@/Components/Label';
+import type { Shape, Sizable, Validity }   from '@/Shared';
+import type { Id, MaybeStringId }          from '@/Shared/UseIdentifiable';
+import type { Disableable }                from '@/Shared/UseState';
 
 export interface SelectOption<T extends number | string = number> extends Id<T>, Disableable {
     readonly text: string;
@@ -21,7 +22,7 @@ interface BaseSelectProps<
     T extends string | number,
     K extends SelectOption<T>,
     V extends SelectOptionType<T, K>,
-> extends MaybeStringId, Disableable, Validity {
+> extends MaybeStringId, Disableable, Validity, WithConfigurableHelperText {
     shape?:  Extract<Shape, 'rounded' | 'pilled'>;
     options: V[];
 }
@@ -31,7 +32,7 @@ export interface SelectProps<
     K extends SelectOption<T> = SelectOption<T>,
     V extends SelectOptionType<T, K> = SelectOptionType<T, K>,
 > extends BaseSelectProps<T, K, V>, Sizable {
-    label?: string | InputLabel<Exclude<LabelType, 'inline'>>; // todo: option label
+    label?: string | InputLabel;
 }
 
 export type DatalistOption<T extends number | string> = Omit<SelectOption<T>, 'isDisabled'>;

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -7,6 +7,7 @@
                  :for="id"
                  :component-name="componentName"
                  :type="defaultLabel.type"
+                 :is-hidden="defaultLabel.isHidden"
         >
             {{ defaultLabel.text }}
         </FoLabel>
@@ -54,6 +55,7 @@
                  :for="id"
                  :component-name="componentName"
                  :type="defaultLabel.type"
+                 :is-hidden="defaultLabel.isHidden"
         >
             {{ defaultLabel.text }}
         </FoLabel>

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -1,9 +1,16 @@
 <template>
     <!--    todo: missing hidden label, multiple options  -->
-    <component :is="floatingLabelClass === '' ? FoFragment : 'div'"
-               v-if="options.length"
-               :class="floatingLabelClass"
+    <div v-if="options.length"
+         :class="defaultLabel?.type === 'floating' && floatingLabelClass"
     >
+        <FoLabel v-if="defaultLabel && defaultLabel.type === 'text'"
+                 :for="id"
+                 :component-name="componentName"
+                 :type="defaultLabel.type"
+        >
+            {{ defaultLabel.text }}
+        </FoLabel>
+
         <select :id="id"
                 v-model="selectedOption"
                 class="select"
@@ -11,7 +18,7 @@
                 :disabled="isDisabled"
                 aria-label="select"
         >
-            <option v-if="defaultLabel?.type === 'text'"
+            <option v-if="defaultLabel?.type === 'inline'"
                     :value="null"
             >
                 {{ defaultLabel.text }}
@@ -37,30 +44,36 @@
             </template>
         </select>
 
-        <FoLabel v-if="defaultLabel && defaultLabel.type !== 'text'"
+        <FoHelperText v-if="selectHelperText !== undefined"
+                      :position="selectHelperText.position"
+        >
+            {{ selectHelperText.text }}
+        </FoHelperText>
+
+        <FoLabel v-if="defaultLabel && defaultLabel.type === 'floating'"
                  :for="id"
                  :component-name="componentName"
                  :type="defaultLabel.type"
         >
             {{ defaultLabel.text }}
         </FoLabel>
-    </component>
+    </div>
 </template>
 
 <script setup lang="ts" generic="T extends string | number, K extends SelectOption<T>">
-import type { SelectOption, SelectProps } from '@/Components/Select';
-import type { ComponentName }             from '@/Shared/Utils/Internal';
-import { FoFragment }                     from '@/Components/Fragment/Internal';
-import { FoLabel, useLabel }              from '@/Components/Label/Internal';
-import { isSelectOptionGroup }            from '@/Components/Select/Internal';
-import { onEmptyOptions }                 from '@/Components/Select/Internal/Lib/OnEmptyOptions.ts';
-import FoSelectOption                     from '@/Components/Select/Internal/UI/FoSelectOption.vue';
-import { useFloatingLabel }               from '@/Shared/UseFloatingLabel/Internal';
-import { useFlyonUIVueAppConfig }         from '@/Shared/UseFlyonUIVueAppConfig';
-import { useShape }                       from '@/Shared/UseShape/Internal';
-import { useSize }                        from '@/Shared/UseSize/Internal';
-import { useValidity }                    from '@/Shared/UseValidity/Internal';
-import { useId, watchEffect }             from 'vue';
+import type { SelectOption, SelectProps }          from '@/Components/Select';
+import type { ComponentName }                      from '@/Shared/Utils/Internal';
+import { FoHelperText, usePositionableHelperText } from '@/Components/HelperText/Internal';
+import { FoLabel, useLabel }                       from '@/Components/Label/Internal';
+import { isSelectOptionGroup }                     from '@/Components/Select/Internal';
+import { onEmptyOptions }                          from '@/Components/Select/Internal/Lib/OnEmptyOptions.ts';
+import FoSelectOption                              from '@/Components/Select/Internal/UI/FoSelectOption.vue';
+import { useFloatingLabel }                        from '@/Shared/UseFloatingLabel/Internal';
+import { useFlyonUIVueAppConfig }                  from '@/Shared/UseFlyonUIVueAppConfig';
+import { useShape }                                from '@/Shared/UseShape/Internal';
+import { useSize }                                 from '@/Shared/UseSize/Internal';
+import { useValidity }                             from '@/Shared/UseValidity/Internal';
+import { useId, watchEffect }                      from 'vue';
 
 const props = withDefaults(defineProps<SelectProps<T, K>>(), {
     isDisabled: undefined,
@@ -79,6 +92,12 @@ const defaultLabel = useLabel(
     config,
     componentName,
     () => props.label,
+);
+
+const selectHelperText = usePositionableHelperText(
+    config,
+    componentName,
+    () => props.helperText,
 );
 
 const [
@@ -101,7 +120,7 @@ watchEffect(() => {
      * So that in case the developer is using the useSelectedOption composable where allowNull is true, but there is no
      * way to automatically select the null option, it will still get one option back that is the first one.
      */
-    if (selectedOption.value === null && defaultLabel.value?.type !== 'text') {
+    if (selectedOption.value === null && defaultLabel.value?.type !== 'inline') {
         const option = props.options[0];
 
         if (isSelectOptionGroup(option)) {

--- a/packages/core/src/Components/Select/UI/FoSelect.vue
+++ b/packages/core/src/Components/Select/UI/FoSelect.vue
@@ -1,8 +1,14 @@
 <template>
-    <!--    todo: missing hidden label, multiple options  -->
+    <!--    todo: multiple options  -->
     <div v-if="options.length"
-         :class="defaultLabel?.type === 'floating' && floatingLabelClass"
+         :class="[icon && useIcon && 'select', defaultLabel?.type === 'floating' && floatingLabelClass]"
     >
+        <FoIcon v-if="icon && useIcon"
+                class="text-base-content/80 my-auto shrink-0"
+                :icon="icon"
+                size="small"
+        />
+
         <FoLabel v-if="defaultLabel && defaultLabel.type === 'text'"
                  :for="id"
                  :component-name="componentName"
@@ -65,6 +71,7 @@
 <script setup lang="ts" generic="T extends string | number, K extends SelectOption<T>">
 import type { SelectOption, SelectProps }          from '@/Components/Select';
 import type { ComponentName }                      from '@/Shared/Utils/Internal';
+import { FoIcon }                                  from '@/Components';
 import { FoHelperText, usePositionableHelperText } from '@/Components/HelperText/Internal';
 import { FoLabel, useLabel }                       from '@/Components/Label/Internal';
 import { isSelectOptionGroup }                     from '@/Components/Select/Internal';
@@ -75,7 +82,7 @@ import { useFlyonUIVueAppConfig }                  from '@/Shared/UseFlyonUIVueA
 import { useShape }                                from '@/Shared/UseShape/Internal';
 import { useSize }                                 from '@/Shared/UseSize/Internal';
 import { useValidity }                             from '@/Shared/UseValidity/Internal';
-import { useId, watchEffect }                      from 'vue';
+import { computed, useId, watchEffect }            from 'vue';
 
 const props = withDefaults(defineProps<SelectProps<T, K>>(), {
     isDisabled: undefined,
@@ -101,6 +108,8 @@ const selectHelperText = usePositionableHelperText(
     componentName,
     () => props.helperText,
 );
+
+const useIcon = computed((): boolean => (defaultLabel.value?.type === 'inline'));
 
 const [
     floatingLabelClass,

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Lib/CreateFlyonUIVueApp.ts
@@ -32,7 +32,7 @@ export const createFlyonUIVueApp: FunctionPlugin<FlyonUIVueAppConfig> = (app: Ap
     const config = useLocalStorage<FlyonUIVueAppDefaultConfig>(
         'flyonui-vue-config',
         initialConfig,
-        { mergeDefaults: true },
+        { mergeDefaults: (storageValue, defaults) => deepMerge(storageValue, defaults) },
     );
 
     const resetConfig = (): void => {

--- a/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
+++ b/packages/core/src/Shared/UseFlyonUIVueAppConfig/Types/FlyonUIVueAppConfig.ts
@@ -74,7 +74,7 @@ export interface ConfigurableComponentProps {
     FoLoading:  ConfigurableProps<LoadingProps>;
     FoMenu:     ConfigurableProps<MenuProps>;
     FoRadio:    ConfigurableProps<ButtonProps>; // todo: temporary
-    FoSelect:   ConfigurableProps<SelectProps> & LabelTypeComponentConfig;
+    FoSelect:   ConfigurableProps<SelectProps> & LabelTypeComponentConfig & HorizontalPositionComponentConfig<HorizontalHelperTextPositionConfig>;
     FoTextarea: ConfigurableProps<
         TextareaProps
         & HorizontalPositionComponentConfig<HorizontalPositionGlobalConfig>

--- a/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
+++ b/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
@@ -3,7 +3,7 @@
          data-test="code-snippet"
          class="vp-raw"
     >
-        <section class="border-neutral/10 rounded-box flex flex-col border p-3 sm:p-6 md:my-8">
+        <section class="gap-4 border-neutral/10 rounded-box flex flex-col border p-3 sm:p-6 md:my-8">
             <div class="gap-4 bg-base-200/20 border-neutral/10 rounded-box not-prose w-full border p-3 sm:p-6"
                  data-test="flyonui-vue-preview"
                  :class="previewGridClass"

--- a/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
+++ b/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
@@ -3,7 +3,7 @@
          data-test="code-snippet"
          class="vp-raw"
     >
-        <section class="border-neutral/10 rounded-box flex flex-col gap-4 border p-3 sm:p-6 md:my-8">
+        <section class="border-neutral/10 rounded-box flex flex-col border p-3 sm:p-6 md:my-8">
             <div class="gap-4 bg-base-200/20 border-neutral/10 rounded-box not-prose w-full border p-3 sm:p-6"
                  data-test="flyonui-vue-preview"
                  :class="previewGridClass"

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -2,8 +2,8 @@ import type { Theme }                           from 'vitepress';
 import type { App, Component, DefineComponent } from 'vue';
 import { VueCodeHighlighter }                   from '@/.vitepress/theme/Components/CodeSnippet/Lib/VueCodeHighlighter';
 import Layout                                   from '@/.vitepress/theme/Components/Layout/UI/Layout.vue';
-import BadgeDocs                                from '@/Components/Badge/BadgeDocs.vue';
 
+import BadgeDocs                          from '@/Components/Badge/BadgeDocs.vue';
 import ButtonDocs                         from '@/Components/Button/ButtonDocs.vue';
 import ListGroupDocs                      from '@/Components/ListGroup/ListGroupDocs.vue';
 import LoadingDocs                        from '@/Components/Loading/LoadingDocs.vue';

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -28,9 +28,13 @@
 
 ## Illustrations
 
-### Label and helper text
+### Label and helper text <Badge type="warning" text="Unreleased" />
 
 <SelectDocs section="with-label-and-helper-text" />
+
+### Hidden label <Badge type="warning" text="Unreleased" />
+
+<SelectDocs section="hidden-label" />
 
 ### Disabled <Badge type="warning" text="Unreleased" />
 

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -28,11 +28,9 @@
 
 ## Illustrations
 
-[//]: # (### Label and helper text)
+### Label and helper text
 
-[//]: # ()
-
-[//]: # (<SelectDocs section="with-label-and-helper-text" />)
+<SelectDocs section="with-label-and-helper-text" />
 
 ### Disabled <Badge type="warning" text="Unreleased" />
 

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -18,6 +18,12 @@
 
 <SelectDocs section="floating-label-size" />
 
+## Illustrations
+
+### Icon <Badge type="warning" text="Unreleased" />
+
+<SelectDocs section="with-icon" />
+
 ### Validation states <Badge type="warning" text="Unreleased" />
 
 <SelectDocs section="validation-state" />
@@ -25,8 +31,6 @@
 ### Shapes <Badge type="warning" text="Unreleased" />
 
 <SelectDocs section="shape" />
-
-## Illustrations
 
 ### Label and helper text <Badge type="warning" text="Unreleased" />
 

--- a/packages/docs/Forms/Select/DefaultSelect.vue
+++ b/packages/docs/Forms/Select/DefaultSelect.vue
@@ -3,6 +3,11 @@
               label="Pick your favorite Movie"
               :options="options"
     />
+
+    <FoSelect v-model="selectedNullableOption"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
+              :options="options"
+    />
 </template>
 
 <script setup lang="ts">
@@ -18,5 +23,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption         = useSelectedOption(options, options.value[0].id, false);
+const selectedNullableOption = useSelectedOption(options, null);
 </script>

--- a/packages/docs/Forms/Select/DefaultSelectSize.vue
+++ b/packages/docs/Forms/Select/DefaultSelectSize.vue
@@ -1,29 +1,29 @@
 <template>
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               size="extraSmall"
     />
 
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               size="small"
     />
 
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
     />
 
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               size="large"
     />
 
     <FoSelect v-model="selectedOption"
-              :label="{ text: 'Pick your favorite Movie' }"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               size="extraLarge"
     />

--- a/packages/docs/Forms/Select/DisabledSelect.vue
+++ b/packages/docs/Forms/Select/DisabledSelect.vue
@@ -1,6 +1,6 @@
 <template>
     <FoSelect v-model="selectedOption"
-              label="Pick your favorite Movie"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               is-disabled
     />

--- a/packages/docs/Forms/Select/SelectDocs.vue
+++ b/packages/docs/Forms/Select/SelectDocs.vue
@@ -25,6 +25,12 @@
                  :component="SelectFloatingLabelSize"
     />
 
+    <CodeSnippet v-else-if="section === 'with-icon'"
+                 id="with-icon"
+                 :code="SelectWithIconRaw"
+                 :component="SelectWithIcon"
+    />
+
     <CodeSnippet v-else-if="section === 'validation-state'"
                  id="validation-state"
                  :code="SelectValidationStateRaw"
@@ -97,6 +103,8 @@ import SelectShape                     from '@/Forms/Select/SelectShape.vue';
 import SelectShapeRaw                  from '@/Forms/Select/SelectShape.vue?raw';
 import SelectValidationState           from '@/Forms/Select/SelectValidationState.vue';
 import SelectValidationStateRaw        from '@/Forms/Select/SelectValidationState.vue?raw';
+import SelectWithIcon                  from '@/Forms/Select/SelectWithIcon.vue';
+import SelectWithIconRaw               from '@/Forms/Select/SelectWithIcon.vue?raw';
 import SelectWithLabelAndHelperText    from '@/Forms/Select/SelectWithLabelAndHelperText.vue';
 import SelectWithLabelAndHelperTextRaw from '@/Forms/Select/SelectWithLabelAndHelperText.vue?raw';
 import SelectWithOptgroup              from '@/Forms/Select/SelectWithOptgroup.vue';
@@ -107,6 +115,7 @@ interface Props {
         | 'floating-label'
         | 'default-size'
         | 'floating-label-size'
+        | 'with-icon'
         | 'validation-state'
         | 'shape'
         | 'with-label-and-helper-text'

--- a/packages/docs/Forms/Select/SelectDocs.vue
+++ b/packages/docs/Forms/Select/SelectDocs.vue
@@ -43,6 +43,12 @@
                  :component="SelectWithLabelAndHelperText"
     />
 
+    <CodeSnippet v-else-if="section === 'hidden-label'"
+                 id="hidden-label"
+                 :code="SelectHiddenLabelRaw"
+                 :component="SelectHiddenLabel"
+    />
+
     <CodeSnippet v-else-if="section === 'disabled'"
                  id="disabled"
                  :code="DisabledSelectRaw"
@@ -83,6 +89,8 @@ import SelectFloatingLabel             from '@/Forms/Select/SelectFloatingLabel.
 import SelectFloatingLabelRaw          from '@/Forms/Select/SelectFloatingLabel.vue?raw';
 import SelectFloatingLabelSize         from '@/Forms/Select/SelectFloatingLabelSize.vue';
 import SelectFloatingLabelSizeRaw      from '@/Forms/Select/SelectFloatingLabelSize.vue?raw';
+import SelectHiddenLabel               from '@/Forms/Select/SelectHiddenLabel.vue';
+import SelectHiddenLabelRaw            from '@/Forms/Select/SelectHiddenLabel.vue?raw';
 import SelectRefUsage                  from '@/Forms/Select/SelectRefUsage.vue';
 import SelectRefUsageRaw               from '@/Forms/Select/SelectRefUsage.vue?raw';
 import SelectShape                     from '@/Forms/Select/SelectShape.vue';
@@ -102,6 +110,7 @@ interface Props {
         | 'validation-state'
         | 'shape'
         | 'with-label-and-helper-text'
+        | 'hidden-label'
         | 'disabled'
         | 'datalist'
         | 'optgroup'

--- a/packages/docs/Forms/Select/SelectHiddenLabel.vue
+++ b/packages/docs/Forms/Select/SelectHiddenLabel.vue
@@ -1,0 +1,27 @@
+<template>
+    <FoSelect v-model="selectedOption"
+              :label="{ text: 'Pick your favorite Movie', isHidden: true }"
+              :options="options"
+    />
+
+    <FoSelect v-model="selectedOption"
+              :label="{ text: 'Pick your favorite Movie', type: 'floating', isHidden: true }"
+              :options="options"
+    />
+</template>
+
+<script setup lang="ts">
+import type { SelectOption }           from 'flyonui-vue';
+import { FoSelect, useSelectedOption } from 'flyonui-vue';
+import { ref }                         from 'vue';
+
+const options = ref<SelectOption[]>([
+    { id: 1, text: 'The Godfather' },
+    { id: 2, text: 'The Shawshank Redemption' },
+    { id: 3, text: 'Pulp Fiction' },
+    { id: 4, text: 'The Dark Knight' },
+    { id: 5, text: `Schindler's List` },
+]);
+
+const selectedOption = useSelectedOption(options, options.value[0].id, false);
+</script>

--- a/packages/docs/Forms/Select/SelectRefUsage.vue
+++ b/packages/docs/Forms/Select/SelectRefUsage.vue
@@ -1,11 +1,11 @@
 <template>
     <FoSelect v-model="favoriteMovie"
-              label="Pick your favorite Movie"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="movies"
     />
 
     <FoSelect v-model="favoriteSeries"
-              label="Pick your favorite Series"
+              :label="{ text: 'Pick your favorite Series', type: 'inline' }"
               :options="series"
     />
 </template>

--- a/packages/docs/Forms/Select/SelectShape.vue
+++ b/packages/docs/Forms/Select/SelectShape.vue
@@ -1,6 +1,6 @@
 <template>
     <FoSelect v-model="selectedOption"
-              label="Pick your favorite Movie"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
     />
 
@@ -10,7 +10,7 @@
     />
 
     <FoSelect v-model="selectedOption"
-              label="Pick your favorite Movie"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
               :options="options"
               shape="pilled"
     />

--- a/packages/docs/Forms/Select/SelectValidationState.vue
+++ b/packages/docs/Forms/Select/SelectValidationState.vue
@@ -37,6 +37,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption         = useSelectedOption(options, null);
+const selectedOption         = useSelectedOption(options, options.value[0].id, false);
 const selectedOptionFloating = useSelectedOption(options, options.value[0].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectWithIcon.vue
+++ b/packages/docs/Forms/Select/SelectWithIcon.vue
@@ -1,0 +1,23 @@
+<template>
+    <FoSelect v-model="selectedOption"
+              :label="{ text: 'Pick your favorite Movie', type: 'inline' }"
+              icon="tabler:movie"
+              :options="options"
+    />
+</template>
+
+<script setup lang="ts">
+import type { SelectOption }           from 'flyonui-vue';
+import { FoSelect, useSelectedOption } from 'flyonui-vue';
+import { ref }                         from 'vue';
+
+const options = ref<SelectOption[]>([
+    { id: 1, text: 'The Godfather' },
+    { id: 2, text: 'The Shawshank Redemption' },
+    { id: 3, text: 'Pulp Fiction' },
+    { id: 4, text: 'The Dark Knight' },
+    { id: 5, text: `Schindler's List` },
+]);
+
+const selectedOption = useSelectedOption(options, null);
+</script>

--- a/packages/docs/Forms/Select/SelectWithLabelAndHelperText.vue
+++ b/packages/docs/Forms/Select/SelectWithLabelAndHelperText.vue
@@ -1,5 +1,4 @@
 <template>
-    <!--     todo: this should use the option instead of text when i will refactor -->
     <FoSelect v-model="selectedOption"
               :label="{ text: 'Pick your favorite Movie', type: 'text' }"
               helper-text="helper text"
@@ -20,5 +19,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption(options, options.value[0].id, false);
 </script>

--- a/packages/docs/Forms/Select/SelectWithOptgroup.vue
+++ b/packages/docs/Forms/Select/SelectWithOptgroup.vue
@@ -29,5 +29,5 @@ const options = ref<SelectOptionType[]>([
     },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption(options, 1, false);
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying an icon in the Select component.
  * Introduced configurable helper text positioning for the Select component.
  * Added support for hidden and floating label types in Select.

* **Enhancements**
  * Improved Select component label handling and styling for various label types.
  * Updated Select component to allow more flexible label and helper text configurations.

* **Documentation**
  * Expanded Select component documentation with new sections on icons, hidden labels, and helper text.
  * Added new usage examples for Select with icons, hidden labels, and label/helper text combinations.

* **Bug Fixes**
  * Adjusted default selection logic for Select to better handle initial values and label types.

* **Style**
  * Minor adjustments to documentation component class ordering and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->