### PR TITLE
fix(docs): Replace code snippet id with data test screenshot section

### DIFF
--- a/packages/core/src/Components/Badge/UI/FoBadge.vue
+++ b/packages/core/src/Components/Badge/UI/FoBadge.vue
@@ -29,6 +29,7 @@
 <script setup lang="ts">
 import type { BadgeProps }                 from '@/Components/Badge';
 import type { ComponentName }              from '@/Shared';
+import type { WithDefaultSlot }            from '@/Shared/Utils/Types/Slots.ts';
 import { FoIcon }                          from '@/Components/Icon';
 import { usePositionableIcon }             from '@/Components/Icon/Internal';
 import { useColor }                        from '@/Shared/UseColor/Internal';
@@ -40,6 +41,8 @@ import { useSize }                         from '@/Shared/UseSize/Internal';
 const props = withDefaults(defineProps<BadgeProps>(), {
     isDismissible: false,
 });
+
+defineSlots<WithDefaultSlot>();
 
 const componentName: ComponentName = 'FoBadge';
 

--- a/packages/core/src/Shared/Utils/Types/ComponentName.ts
+++ b/packages/core/src/Shared/Utils/Types/ComponentName.ts
@@ -3,6 +3,7 @@ import type { ConfigurableComponentProps } from '@/Shared/UseFlyonUIVueAppConfig
 type NonConfigurableComponentName = 'FoJoin'
     | 'FoCheckboxGroup'
     | 'FoDatalist'
+    | 'FoDotStyleBadge'
     | 'FoLabel'
     | 'FoListGroup'
     | 'FoListGroupItem'

--- a/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
+++ b/packages/docs/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue
@@ -1,5 +1,5 @@
 <template>
-    <section :id="id"
+    <section :id="dataTestScreenshot"
              data-test="code-snippet"
              class="vp-raw gap-4 border-neutral/10 rounded-box flex flex-col border p-3 sm:p-6 md:my-8"
     >
@@ -31,7 +31,7 @@ interface Props {
      * Used mainly as name of the screenshot preview for visual tests, In case it is undefined, it means that it
      * is by purpose as not everything can be tested through screenshots, such as animations.
      */
-    id?:      string;
+    dataTestScreenshot?: string;
     preview?: {
         columns: number;
         rows:    number;

--- a/packages/docs/Components/Badge.md
+++ b/packages/docs/Components/Badge.md
@@ -47,3 +47,13 @@
 ### In a button
 
 <BadgeDocs section="in-a-button" />
+
+## Api
+
+### Props
+
+<BadgeDocs section="props" />
+
+### Slots
+
+<BadgeDocs section="slots" />

--- a/packages/docs/Components/Badge/BadgeDocs.vue
+++ b/packages/docs/Components/Badge/BadgeDocs.vue
@@ -1,68 +1,75 @@
 <template>
     <CodeSnippet v-if="section === 'solid'"
-                 id="solid"
+                 :data-test-screenshot="section"
                  :code="SolidBadgeRaw"
                  :component="SolidBadge"
     />
 
     <CodeSnippet v-else-if="section === 'soft'"
-                 id="soft"
+                 :data-test-screenshot="section"
                  :code="SoftBadgeRaw"
                  :component="SoftBadge"
     />
 
     <CodeSnippet v-else-if="section === 'outline'"
-                 id="outline"
+                 :data-test-screenshot="section"
                  :code="OutlineBadgeRaw"
                  :component="OutlineBadge"
     />
 
     <CodeSnippet v-else-if="section === 'dash'"
-                 id="dash"
+                 :data-test-screenshot="section"
                  :code="DashedBadgeRaw"
                  :component="DashedBadge"
     />
 
     <CodeSnippet v-else-if="section === 'pilled'"
-                 id="pilled"
+                 :data-test-screenshot="section"
                  :code="PilledBadgeRaw"
                  :component="PilledBadge"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="BadgeSizeRaw"
                  :component="BadgeSize"
     />
 
     <CodeSnippet v-else-if="section === 'dot-style'"
-                 id="dot-style"
+                 :data-test-screenshot="section"
                  :code="DotStyleBadgeRaw"
                  :component="DotStyleBadge"
     />
 
     <CodeSnippet v-else-if="section === 'icon'"
-                 id="icon"
+                 :data-test-screenshot="section"
                  :code="IconBadgeRaw"
                  :component="IconBadge"
                  :preview="{ columns: 8, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'icon-position'"
-                 id="icon-position"
+                 :data-test-screenshot="section"
                  :code="IconPositionBadgeRaw"
                  :component="IconPositionBadge"
     />
 
     <CodeSnippet v-else-if="section === 'in-a-button'"
-                 id="in-a-button"
+                 :data-test-screenshot="section"
                  :code="BadgeInAButtonRaw"
                  :component="BadgeInAButton"
+    />
+
+    <ComponentsApiDocs v-else
+                       :section="section"
+                       :component-names="['FoBadge', 'FoDotStyleBadge']"
     />
 </template>
 
 <script setup lang="ts">
+import type { ApiType }     from '@/Api/Types/Api.ts';
 import CodeSnippet          from '@/.vitepress/theme/Components/CodeSnippet/UI/CodeSnippet.vue';
+import ComponentsApiDocs    from '@/Api/UI/ComponentsApiDocs.vue';
 import BadgeInAButton       from '@/Components/Badge/BadgeInAButton.vue';
 import BadgeInAButtonRaw    from '@/Components/Badge/BadgeInAButton.vue?raw';
 import BadgeSize            from '@/Components/Badge/BadgeSize.vue';
@@ -86,7 +93,17 @@ import SolidBadgeRaw        from '@/Components/Badge/SolidBadge.vue?raw';
 
 // todo: dismissible badges
 interface Props {
-    section: 'solid' | 'soft' | 'outline' | 'dash' | 'pilled' | 'size' | 'dot-style' | 'icon' | 'icon-position' | 'in-a-button';
+    section: 'solid'
+        | 'soft'
+        | 'outline'
+        | 'dash'
+        | 'pilled'
+        | 'size'
+        | 'dot-style'
+        | 'icon'
+        | 'icon-position'
+        | 'in-a-button'
+        | ApiType;
 }
 
 defineProps<Props>();

--- a/packages/docs/Components/Button/ButtonDocs.vue
+++ b/packages/docs/Components/Button/ButtonDocs.vue
@@ -1,84 +1,84 @@
 <template>
     <CodeSnippet v-if="section === 'solid'"
-                 id="solid"
+                 :data-test-screenshot="section"
                  :code="DefaultButtonRaw"
                  :component="DefaultButton"
     />
 
     <CodeSnippet v-else-if="section === 'soft'"
-                 id="soft"
+                 :data-test-screenshot="section"
                  :code="SoftButtonRaw"
                  :component="SoftButton"
     />
 
     <CodeSnippet v-else-if="section === 'outline'"
-                 id="outline"
+                 :data-test-screenshot="section"
                  :code="OutlineButtonRaw"
                  :component="OutlineButton"
     />
 
     <CodeSnippet v-else-if="section === 'dash'"
-                 id="dash"
+                 :data-test-screenshot="section"
                  :code="DashedButtonRaw"
                  :component="DashedButton"
     />
 
     <CodeSnippet v-else-if="section === 'text'"
-                 id="text"
+                 :data-test-screenshot="section"
                  :code="TextButtonRaw"
                  :component="TextButton"
     />
 
     <CodeSnippet v-else-if="section === 'gradient'"
-                 id="gradient"
+                 :data-test-screenshot="section"
                  :code="GradientButtonRaw"
                  :component="GradientButton"
     />
 
     <CodeSnippet v-else-if="section === 'pilled'"
-                 id="pilled"
+                 :data-test-screenshot="section"
                  :code="PilledButtonRaw"
                  :component="PilledButton"
     />
 
     <CodeSnippet v-else-if="section === 'validation-state'"
-                 id="state"
+                 :data-test-screenshot="section"
                  :code="ButtonStateRaw"
                  :component="ButtonState"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="ButtonSizeRaw"
                  :component="ButtonSize"
     />
 
     <CodeSnippet v-else-if="section === 'layout'"
-                 id="layout"
+                 :data-test-screenshot="section"
                  :code="ButtonLayoutRaw"
                  :component="ButtonLayout"
     />
 
     <CodeSnippet v-else-if="section === 'icon'"
-                 id="icon"
+                 :data-test-screenshot="section"
                  :code="IconButtonRaw"
                  :component="IconButton"
     />
 
     <CodeSnippet v-else-if="section === 'icon-position'"
-                 id="icon-position"
+                 :data-test-screenshot="section"
                  :code="IconPositionButtonRaw"
                  :component="IconPositionButton"
     />
 
     <CodeSnippet v-else-if="section === 'social'"
-                 id="social"
+                 :data-test-screenshot="section"
                  :code="SocialButtonRaw"
                  :component="SocialButton"
     />
 
     <CodeSnippet v-else-if="section === 'social-shape'"
-                 id="social-shape"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 4, rows: 3 }"
                  :code="SocialButtonShapeRaw"
                  :component="SocialButtonShape"
@@ -90,7 +90,7 @@
     />
 
     <CodeSnippet v-else-if="section === 'glass'"
-                 id="glass"
+                 :data-test-screenshot="section"
                  :code="GlassButtonRaw"
                  :component="GlassButton"
     />

--- a/packages/docs/Components/ListGroup/ListGroupDocs.vue
+++ b/packages/docs/Components/ListGroup/ListGroupDocs.vue
@@ -1,55 +1,55 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultListGroupRaw"
                  :component="DefaultListGroup"
     />
 
     <CodeSnippet v-else-if="section === 'with-icons'"
-                 id="with-icons"
+                 :data-test-screenshot="section"
                  :code="ListGroupWithIconsRaw"
                  :component="ListGroupWithIcons"
     />
 
     <CodeSnippet v-else-if="section === 'with-badges'"
-                 id="with-badges"
+                 :data-test-screenshot="section"
                  :code="ListGroupWithBadgesRaw"
                  :component="ListGroupWithBadges"
     />
 
     <CodeSnippet v-else-if="section === 'horizontal'"
-                 id="horizontal"
+                 :data-test-screenshot="section"
                  :code="HorizontalListGroupRaw"
                  :component="HorizontalListGroup"
     />
 
     <CodeSnippet v-else-if="section === 'flushed'"
-                 id="flushed"
+                 :data-test-screenshot="section"
                  :code="FlushedListGroupRaw"
                  :component="FlushedListGroup"
     />
 
     <CodeSnippet v-else-if="section === 'without-gutters'"
-                 id="without-gutters"
+                 :data-test-screenshot="section"
                  :code="ListGroupWithoutGuttersRaw"
                  :component="ListGroupWithoutGutters"
     />
 
     <CodeSnippet v-else-if="section === 'striped'"
-                 id="striped"
+                 :data-test-screenshot="section"
                  :code="StripedListGroupRaw"
                  :component="StripedListGroup"
     />
 
     <CodeSnippet v-else-if="section === 'with-checkbox'"
-                 id="with-checkbox"
+                 :data-test-screenshot="section"
                  :code="ListGroupWithCheckboxRaw"
                  :component="ListGroupWithCheckbox"
                  :preview="{ columns: 1, rows: 1 }"
     />
 
     <CodeSnippet v-else-if="section === 'invoice'"
-                 id="invoice"
+                 :data-test-screenshot="section"
                  :code="InvoiceListGroupRaw"
                  :component="InvoiceListGroup"
     />

--- a/packages/docs/Components/Stats/StatsDocs.vue
+++ b/packages/docs/Components/Stats/StatsDocs.vue
@@ -1,48 +1,48 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultStatsRaw"
                  :component="DefaultStats"
     />
 
     <CodeSnippet v-else-if="section === 'with-avatar'"
-                 id="with-avatar"
+                 :data-test-screenshot="section"
                  :code="StatsWithAvatarRaw"
                  :component="StatsWithAvatar"
     />
 
     <CodeSnippet v-else-if="section === 'with-icons-and-image'"
-                 id="with-icons-and-image"
+                 :data-test-screenshot="section"
                  :code="StatsWithIconsAndImageRaw"
                  :component="StatsWithIconsAndImage"
     />
 
     <CodeSnippet v-else-if="section === 'centered-item'"
-                 id="centered-item"
+                 :data-test-screenshot="section"
                  :code="CenteredItemStatsRaw"
                  :component="CenteredItemStats"
     />
 
     <CodeSnippet v-else-if="section === 'vertical'"
-                 id="vertical"
+                 :data-test-screenshot="section"
                  :code="VerticalStatsRaw"
                  :component="VerticalStats"
     />
 
     <CodeSnippet v-else-if="section === 'with-progress-bar'"
-                 id="with-progress-bar"
+                 :data-test-screenshot="section"
                  :code="StatsWithProgressBarRaw"
                  :component="StatsWithProgressBar"
     />
 
     <CodeSnippet v-else-if="section === 'with-actions-button'"
-                 id="with-actions-button"
+                 :data-test-screenshot="section"
                  :code="StatsWithActionsButtonRaw"
                  :component="StatsWithActionsButton"
     />
 
     <CodeSnippet v-else-if="section === 'bordered'"
-                 id="bordered"
+                 :data-test-screenshot="section"
                  :code="BorderedStatsRaw"
                  :component="BorderedStats"
     />

--- a/packages/docs/Components/Swap/SwapDocs.vue
+++ b/packages/docs/Components/Swap/SwapDocs.vue
@@ -1,18 +1,18 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultSwapRaw"
                  :component="DefaultSwap"
     />
 
     <CodeSnippet v-else-if="section === 'rotation'"
-                 id="rotation"
+                 :data-test-screenshot="section"
                  :code="SwapRotationRaw"
                  :component="SwapRotation"
     />
 
     <CodeSnippet v-else-if="section === 'flip'"
-                 id="flip"
+                 :data-test-screenshot="section"
                  :code="SwapFlipRaw"
                  :component="SwapFlip"
     />

--- a/packages/docs/Content/Heading/HeadingDocs.vue
+++ b/packages/docs/Content/Heading/HeadingDocs.vue
@@ -1,6 +1,6 @@
 <template>
     <CodeSnippet v-if="section === 'level'"
-                 id="level"
+                 :data-test-screenshot="section"
                  :code="HeadingLevelRaw"
                  :component="HeadingLevel"
                  :preview="{ columns: 1, rows: 6 }"

--- a/packages/docs/Content/Keyboard/KeyboardDocs.vue
+++ b/packages/docs/Content/Keyboard/KeyboardDocs.vue
@@ -1,48 +1,48 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="DefaultKeyboardRaw"
                  :component="DefaultKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="KeyboardSizeRaw"
                  :component="KeyboardSize"
     />
 
     <CodeSnippet v-else-if="section === 'in-text'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="InTextKeyboardRaw"
                  :component="InTextKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'key-combinations'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="KeyCombinationsKeyboardRaw"
                  :component="KeyCombinationsKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'function-keys'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="FunctionKeysKeyboardRaw"
                  :component="FunctionKeysKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'full-keyboard'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="FullKeyboardRaw"
                  :component="FullKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'arrow-keys'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="ArrowKeysKeyboardRaw"
                  :component="ArrowKeysKeyboard"
     />
 
     <CodeSnippet v-else-if="section === 'number-keys'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="NumberKeysKeyboardRaw"
                  :component="NumberKeysKeyboard"
     />

--- a/packages/docs/Content/Link/LinkDocs.vue
+++ b/packages/docs/Content/Link/LinkDocs.vue
@@ -1,24 +1,24 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultLinkRaw"
                  :component="DefaultLink"
     />
 
     <CodeSnippet v-else-if="section === 'underline-on-hover'"
-                 id="underline-on-hover"
+                 :data-test-screenshot="section"
                  :code="UnderlineOnHoverLinkRaw"
                  :component="UnderlineOnHoverLink"
     />
 
     <CodeSnippet v-else-if="section === 'animated-underline'"
-                 id="animated-underline"
+                 :data-test-screenshot="section"
                  :code="AnimatedUnderlineLinkRaw"
                  :component="AnimatedUnderlineLink"
     />
 
     <CodeSnippet v-else-if="section === 'color'"
-                 id="color"
+                 :data-test-screenshot="section"
                  :code="LinkColorRaw"
                  :component="LinkColor"
     />

--- a/packages/docs/Content/Mask/MaskDocs.vue
+++ b/packages/docs/Content/Mask/MaskDocs.vue
@@ -1,13 +1,13 @@
 <template>
     <CodeSnippet v-if="section === 'shape'"
-                 id="shape"
+                 :data-test-screenshot="section"
                  :code="MaskShapeRaw"
                  :component="MaskShape"
                  :preview="{ columns: 4, rows: 6 }"
     />
 
     <CodeSnippet v-else-if="section === 'v-mask'"
-                 id="v-mask"
+                 :data-test-screenshot="section"
                  :code="VMaskRaw"
                  :component="VMask"
                  :preview="{ columns: 4, rows: 6 }"

--- a/packages/docs/Customisation/Icons/IconsDocs.vue
+++ b/packages/docs/Customisation/Icons/IconsDocs.vue
@@ -5,7 +5,7 @@
     />
 
     <CodeSnippet v-else-if="section === 'custom'"
-                 id="custom"
+                 :data-test-screenshot="section"
                  :code="[
                      { title: 'Vue', code: CustomIconRaw },
                      { title: 'SvgIcon.vue', code: SvgIconRaw },
@@ -14,7 +14,7 @@
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="IconSizeRaw"
                  :component="IconSize"
     />

--- a/packages/docs/Forms/Checkbox/CheckboxDocs.vue
+++ b/packages/docs/Forms/Checkbox/CheckboxDocs.vue
@@ -1,54 +1,54 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultCheckboxRaw"
                  :component="DefaultCheckbox"
     />
 
     <CodeSnippet v-else-if="section === 'with-helper-text'"
-                 id="with-helper-text"
+                 :data-test-screenshot="section"
                  :code="CheckboxWithHelperTextRaw"
                  :component="CheckboxWithHelperText"
     />
 
     <CodeSnippet v-else-if="section === 'color'"
-                 id="color"
+                 :data-test-screenshot="section"
                  :code="CheckboxColorRaw"
                  :component="CheckboxColor"
     />
 
     <CodeSnippet v-else-if="section === 'with-custom-color'"
-                 id="with-custom-color"
+                 :data-test-screenshot="section"
                  :code="CheckboxWithCustomColorRaw"
                  :component="CheckboxWithCustomColor"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="CheckboxSizeRaw"
                  :component="CheckboxSize"
     />
 
     <CodeSnippet v-else-if="section === 'validation-state'"
-                 id="validation-state"
+                 :data-test-screenshot="section"
                  :code="CheckboxValidationStateRaw"
                  :component="CheckboxValidationState"
     />
 
     <CodeSnippet v-else-if="section === 'state'"
-                 id="state"
+                 :data-test-screenshot="section"
                  :code="CheckboxStateRaw"
                  :component="CheckboxState"
     />
 
     <CodeSnippet v-else-if="section === 'inline-group'"
-                 id="inline-group"
+                 :data-test-screenshot="section"
                  :code="InlineCheckboxGroupRaw"
                  :component="InlineCheckboxGroup"
     />
 
     <CodeSnippet v-else-if="section === 'vertical-group'"
-                 id="vertical-group"
+                 :data-test-screenshot="section"
                  :code="VerticalCheckboxGroupRaw"
                  :component="VerticalCheckboxGroup"
     />

--- a/packages/docs/Forms/InputText/InputTextDocs.vue
+++ b/packages/docs/Forms/InputText/InputTextDocs.vue
@@ -1,96 +1,96 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultInputTextRaw"
                  :component="DefaultInputText"
     />
 
     <CodeSnippet v-else-if="section === 'with-placeholder'"
-                 id="with-placeholder"
+                 :data-test-screenshot="section"
                  :code="InputTextWithPlaceholderRaw"
                  :component="InputTextWithPlaceholder"
     />
 
     <CodeSnippet v-else-if="section === 'with-label-and-helper-text'"
-                 id="with-label-and-helper-text"
+                 :data-test-screenshot="section"
                  :code="InputTextWithLabelAndHelperTextRaw"
                  :component="InputTextWithLabelAndHelperText"
                  :preview="{ columns: 1, rows: 4 }"
     />
 
     <CodeSnippet v-else-if="section === 'hidden-label'"
-                 id="hidden-label"
+                 :data-test-screenshot="section"
                  :code="InputTextHiddenLabelRaw"
                  :component="InputTextHiddenLabel"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label'"
-                 id="floating-label"
+                 :data-test-screenshot="section"
                  :code="InputTextFloatingLabelRaw"
                  :component="InputTextFloatingLabel"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="InputTextSizeRaw"
                  :component="InputTextSize"
                  :preview="{ columns: 1, rows: 4 }"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label-size'"
-                 id="floating-label-size"
+                 :data-test-screenshot="section"
                  :code="InputTextFloatingLabelSizeRaw"
                  :component="InputTextFloatingLabelSize"
                  :preview="{ columns: 1, rows: 3 }"
     />
 
     <CodeSnippet v-else-if="section === 'validation-state'"
-                 id="validation-state"
+                 :data-test-screenshot="section"
                  :code="InputTextValidationStateRaw"
                  :component="InputTextValidationState"
                  :preview="{ columns: 1, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'inline-label'"
-                 id="inline-label"
+                 :data-test-screenshot="section"
                  :code="InputTextInlineLabelRaw"
                  :component="InputTextInlineLabel"
     />
 
     <CodeSnippet v-else-if="section === 'with-icon'"
-                 id="with-icon"
+                 :data-test-screenshot="section"
                  :code="InputTextWithIconRaw"
                  :component="InputTextWithIcon"
     />
 
     <CodeSnippet v-else-if="section === 'shape'"
-                 id="shape"
+                 :data-test-screenshot="section"
                  :code="InputTextShapeRaw"
                  :component="InputTextShape"
                  :preview="{ columns: 1, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'without-focus'"
-                 id="without-focus"
+                 :data-test-screenshot="section"
                  :code="InputTextWithoutFocusRaw"
                  :component="InputTextWithoutFocus"
     />
 
     <CodeSnippet v-else-if="section === 'disabled'"
-                 id="disabled"
+                 :data-test-screenshot="section"
                  :code="DisabledInputTextRaw"
                  :component="DisabledInputText"
                  :preview="{ columns: 1, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'readonly'"
-                 id="readonly"
+                 :data-test-screenshot="section"
                  :code="ReadonlyInputTextRaw"
                  :component="ReadonlyInputText"
     />
 
     <CodeSnippet v-else-if="section === 'join'"
-                 id="join"
+                 :data-test-screenshot="section"
                  :code="JoinInputTextRaw"
                  :component="JoinInputText"
     />

--- a/packages/docs/Forms/Join/JoinDocs.vue
+++ b/packages/docs/Forms/Join/JoinDocs.vue
@@ -1,30 +1,30 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultJoinRaw"
                  :component="DefaultJoin"
     />
 
     <CodeSnippet v-else-if="section === 'icon'"
-                 id="icon"
+                 :data-test-screenshot="section"
                  :code="JoinIconRaw"
                  :component="JoinIcon"
     />
 
     <CodeSnippet v-else-if="section === 'vertical'"
-                 id="vertical"
+                 :data-test-screenshot="section"
                  :code="VerticalJoinRaw"
                  :component="VerticalJoin"
     />
 
     <CodeSnippet v-else-if="section === 'responsive'"
-                 id="responsive"
+                 :data-test-screenshot="section"
                  :code="ResponsiveJoinRaw"
                  :component="ResponsiveJoin"
     />
 
     <CodeSnippet v-else-if="section === 'pilled'"
-                 id="pilled"
+                 :data-test-screenshot="section"
                  :code="PilledJoinRaw"
                  :component="PilledJoin"
     />

--- a/packages/docs/Forms/Select/SelectDocs.vue
+++ b/packages/docs/Forms/Select/SelectDocs.vue
@@ -1,86 +1,86 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultSelectRaw"
                  :preview="{ columns: 1, rows: 2 }"
                  :component="DefaultSelect"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label'"
-                 id="floating-label"
+                 :data-test-screenshot="section"
                  :code="SelectFloatingLabelRaw"
                  :component="SelectFloatingLabel"
     />
 
     <CodeSnippet v-else-if="section === 'default-size'"
-                 id="default-size"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 4 }"
                  :code="DefaultSelectSizeRaw"
                  :component="DefaultSelectSize"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label-size'"
-                 id="floating-label-size"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 3 }"
                  :code="SelectFloatingLabelSizeRaw"
                  :component="SelectFloatingLabelSize"
     />
 
     <CodeSnippet v-else-if="section === 'with-icon'"
-                 id="with-icon"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 2 }"
                  :code="SelectWithIconRaw"
                  :component="SelectWithIcon"
     />
 
     <CodeSnippet v-else-if="section === 'validation-state'"
-                 id="validation-state"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 4 }"
                  :code="SelectValidationStateRaw"
                  :component="SelectValidationState"
     />
 
     <CodeSnippet v-else-if="section === 'shape'"
-                 id="shape"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 4 }"
                  :code="SelectShapeRaw"
                  :component="SelectShape"
     />
 
     <CodeSnippet v-else-if="section === 'with-label-and-helper-text'"
-                 id="with-label-and-helper-text"
+                 :data-test-screenshot="section"
                  :code="SelectWithLabelAndHelperTextRaw"
                  :component="SelectWithLabelAndHelperText"
     />
 
     <CodeSnippet v-else-if="section === 'hidden-label'"
-                 id="hidden-label"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 2 }"
                  :code="SelectHiddenLabelRaw"
                  :component="SelectHiddenLabel"
     />
 
     <CodeSnippet v-else-if="section === 'disabled'"
-                 id="disabled"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 2 }"
                  :code="DisabledSelectRaw"
                  :component="DisabledSelect"
     />
 
     <CodeSnippet v-else-if="section === 'datalist'"
-                 id="datalist"
+                 :data-test-screenshot="section"
                  :code="SelectAsDatalistRaw"
                  :component="SelectAsDatalist"
     />
 
     <CodeSnippet v-else-if="section === 'optgroup'"
-                 id="optgroup"
+                 :data-test-screenshot="section"
                  :code="SelectWithOptgroupRaw"
                  :component="SelectWithOptgroup"
     />
 
     <CodeSnippet v-else-if="section === 'ref-usage'"
-                 id="ref-usage"
+                 :data-test-screenshot="section"
                  :preview="{ columns: 1, rows: 2 }"
                  :code="SelectRefUsageRaw"
                  :component="SelectRefUsage"

--- a/packages/docs/Forms/Textarea/TextareaDocs.vue
+++ b/packages/docs/Forms/Textarea/TextareaDocs.vue
@@ -1,76 +1,76 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultTextareaRaw"
                  :component="DefaultTextarea"
                  :preview="{ columns: 1, rows: 1 }"
     />
 
     <CodeSnippet v-else-if="section === 'with-label-and-placeholder'"
-                 id="with-label-and-placeholder"
+                 :data-test-screenshot="section"
                  :code="TextareaWithLabelAndPlaceholderRaw"
                  :component="TextareaWithLabelAndPlaceholder"
                  :preview="{ columns: 1, rows: 1 }"
     />
 
     <CodeSnippet v-else-if="section === 'hidden-label'"
-                 id="hidden-label"
+                 :data-test-screenshot="section"
                  :code="TextareaHiddenLabelRaw"
                  :component="TextareaHiddenLabel"
                  :preview="{ columns: 1, rows: 1 }"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label'"
-                 id="floating-label"
+                 :data-test-screenshot="section"
                  :code="TextareaFloatingLabelRaw"
                  :component="TextareaFloatingLabel"
                  :preview="{ columns: 1, rows: 1 }"
     />
 
     <CodeSnippet v-else-if="section === 'default-size'"
-                 id="default-size"
+                 :data-test-screenshot="section"
                  :code="TextareaDefaultSizeRaw"
                  :component="TextareaDefaultSize"
                  :preview="{ columns: 1, rows: 5 }"
     />
 
     <CodeSnippet v-else-if="section === 'floating-label-size'"
-                 id="floating-label-size"
+                 :data-test-screenshot="section"
                  :code="TextareaFloatingLabelSizeRaw"
                  :component="TextareaFloatingLabelSize"
                  :preview="{ columns: 1, rows: 5 }"
     />
 
     <CodeSnippet v-else-if="section === 'with-icon'"
-                 id="with-icon"
+                 :data-test-screenshot="section"
                  :code="TextareaWithIconRaw"
                  :component="TextareaWithIcon"
                  :preview="{ columns: 1, rows: 6 }"
     />
 
     <CodeSnippet v-else-if="section === 'with-helper-text'"
-                 id="with-helper-text"
+                 :data-test-screenshot="section"
                  :code="TextareaWithHelperTextRaw"
                  :component="TextareaWithHelperText"
                  :preview="{ columns: 1, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'validation-state'"
-                 id="validation-state"
+                 :data-test-screenshot="section"
                  :code="TextareaValidationStateRaw"
                  :component="TextareaValidationState"
                  :preview="{ columns: 1, rows: 4 }"
     />
 
     <CodeSnippet v-else-if="section === 'disabled'"
-                 id="disabled"
+                 :data-test-screenshot="section"
                  :code="DisabledTextareaRaw"
                  :component="DisabledTextarea"
                  :preview="{ columns: 1, rows: 2 }"
     />
 
     <CodeSnippet v-else-if="section === 'readonly'"
-                 id="readonly"
+                 :data-test-screenshot="section"
                  :code="ReadonlyTextareaRaw"
                  :component="ReadonlyTextarea"
                  :preview="{ columns: 1, rows: 1 }"

--- a/packages/docs/Navigations/Menu/MenuDocs.vue
+++ b/packages/docs/Navigations/Menu/MenuDocs.vue
@@ -1,84 +1,84 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultMenuRaw"
                  :component="DefaultMenu"
     />
 
     <CodeSnippet v-else-if="section === 'icon'"
-                 id="icon"
+                 :data-test-screenshot="section"
                  :code="IconMenuRaw"
                  :component="IconMenu"
     />
 
     <CodeSnippet v-else-if="section === 'only-icon'"
-                 id="only-icon"
+                 :data-test-screenshot="section"
                  :code="OnlyIconMenuRaw"
                  :component="OnlyIconMenu"
     />
 
     <CodeSnippet v-else-if="section === 'orientation'"
-                 id="orientation"
+                 :data-test-screenshot="section"
                  :code="MenuOrientationRaw"
                  :component="MenuOrientation"
     />
 
     <CodeSnippet v-else-if="section === 'with-tooltip'"
-                 id="with-tooltip"
+                 :data-test-screenshot="section"
                  :code="MenuWithTooltipRaw"
                  :component="MenuWithTooltip"
     />
 
     <CodeSnippet v-else-if="section === 'with-disabled-item'"
-                 id="with-disabled-item"
+                 :data-test-screenshot="section"
                  :code="DisabledItemMenuRaw"
                  :component="DisabledItemMenu"
     />
 
     <CodeSnippet v-else-if="section === 'with-badge'"
-                 id="with-badge"
+                 :data-test-screenshot="section"
                  :code="MenuWithBadgeRaw"
                  :component="MenuWithBadge"
     />
 
     <CodeSnippet v-else-if="section === 'with-active-item-vue-router'"
-                 id="with-active-item-vue-router"
+                 :data-test-screenshot="section"
                  :code="ActiveItemMenuVueRouterRaw"
                  :component="ActiveItemMenuExternalRouter"
     />
 
     <CodeSnippet v-else-if="section === 'with-active-item-external-router'"
-                 id="with-active-item-external-router"
+                 :data-test-screenshot="section"
                  :code="ActiveItemMenuExternalRouterRaw"
                  :component="ActiveItemMenuExternalRouter"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 id="size"
+                 :data-test-screenshot="section"
                  :code="MenuSizeRaw"
                  :component="MenuSize"
     />
 
     <CodeSnippet v-else-if="section === 'flushed'"
-                 id="flushed"
+                 :data-test-screenshot="section"
                  :code="FlushedMenuRaw"
                  :component="FlushedMenu"
     />
 
     <CodeSnippet v-else-if="section === 'with-title'"
-                 id="with-title"
+                 :data-test-screenshot="section"
                  :code="MenuWithTitleRaw"
                  :component="MenuWithTitle"
     />
 
     <CodeSnippet v-else-if="section === 'with-title-as-parent'"
-                 id="with-title-as-parent"
+                 :data-test-screenshot="section"
                  :code="MenuWithTitleAsParentRaw"
                  :component="MenuWithTitleAsParent"
     />
 
     <CodeSnippet v-else-if="section === 'with-submenu'"
-                 id="with-submenu"
+                 :data-test-screenshot="section"
                  :code="[
                      {
                          title: 'Item.ts',
@@ -97,7 +97,7 @@
     />
 
     <CodeSnippet v-else-if="section === 'with-horizontal-submenu'"
-                 id="with-horizontal-submenu"
+                 :data-test-screenshot="section"
                  :code="[
                      {
                          title: 'Item.ts',
@@ -116,7 +116,7 @@
     />
 
     <CodeSnippet v-else-if="section === 'mega-with-submenu'"
-                 id="mega-with-submenu"
+                 :data-test-screenshot="section"
                  :code="[
                      {
                          title: 'Item.ts',

--- a/packages/docs/Navigations/Navbar/NavbarDocs.vue
+++ b/packages/docs/Navigations/Navbar/NavbarDocs.vue
@@ -1,12 +1,12 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultNavbarRaw"
                  :component="DefaultNavbar"
     />
 
     <CodeSnippet v-else-if="section === 'with-logo'"
-                 id="with-logo"
+                 :data-test-screenshot="section"
                  :code="NavbarWithLogoRaw"
                  :component="NavbarWithLogo"
     />

--- a/packages/docs/Overlays/Popover/PopoverDocs.vue
+++ b/packages/docs/Overlays/Popover/PopoverDocs.vue
@@ -1,18 +1,18 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultPopoverRaw"
                  :component="DefaultPopover"
     />
 
     <CodeSnippet v-else-if="section === 'color'"
-                 id="color"
+                 :data-test-screenshot="section"
                  :code="PopoverColorRaw"
                  :component="PopoverColor"
     />
 
     <CodeSnippet v-else-if="section === 'placement'"
-                 id="placement"
+                 :data-test-screenshot="section"
                  :code="PopoverPlacementRaw"
                  :component="PopoverPlacement"
     />

--- a/packages/docs/Overlays/Tooltip/TooltipDocs.vue
+++ b/packages/docs/Overlays/Tooltip/TooltipDocs.vue
@@ -1,18 +1,18 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 id="default"
+                 :data-test-screenshot="section"
                  :code="DefaultTooltipRaw"
                  :component="DefaultTooltip"
     />
 
     <CodeSnippet v-else-if="section === 'color'"
-                 id="color"
+                 :data-test-screenshot="section"
                  :code="TooltipColorRaw"
                  :component="TooltipColor"
     />
 
     <CodeSnippet v-else-if="section === 'placement'"
-                 id="placement"
+                 :data-test-screenshot="section"
                  :code="TooltipPlacementRaw"
                  :component="TooltipPlacement"
     />

--- a/packages/docs/Tables/Table/TableDocs.vue
+++ b/packages/docs/Tables/Table/TableDocs.vue
@@ -1,102 +1,102 @@
 <template>
     <CodeSnippet v-if="section === 'default'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="DefaultTableRaw"
                  :component="DefaultTable"
     />
 
     <CodeSnippet v-else-if="section === 'bordered'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="BorderedTableRaw"
                  :component="BorderedTable"
     />
 
     <CodeSnippet v-else-if="section === 'borderless'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="BorderlessTableRaw"
                  :component="BorderlessTable"
     />
 
     <CodeSnippet v-else-if="section === 'hoverable'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="HoverableTableRaw"
                  :component="HoverableTable"
     />
 
     <CodeSnippet v-else-if="section === 'with-highlight'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableWithHighlightRaw"
                  :component="TableWithHighlight"
     />
 
     <CodeSnippet v-else-if="section === 'striped-rows'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="StripedTableRowsRaw"
                  :component="StripedTableRows"
     />
 
     <CodeSnippet v-else-if="section === 'striped-columns'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="StripedTableColumnsRaw"
                  :component="StripedTableColumns"
     />
 
     <CodeSnippet v-else-if="section === 'rounded'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="RoundedTableRaw"
                  :component="RoundedTable"
     />
 
     <CodeSnippet v-else-if="section === 'size'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableSizeRaw"
                  :component="TableSize"
     />
 
     <CodeSnippet v-else-if="section === 'pinned-rows'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="PinnedRowsTableRaw"
                  :component="PinnedRowsTable"
     />
 
     <CodeSnippet v-else-if="section === 'pinned-columns'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="PinnedColumnsTableRaw"
                  :component="PinnedColumnsTable"
     />
 
     <CodeSnippet v-else-if="section === 'headless'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="HeadlessTableRaw"
                  :component="HeadlessTable"
     />
 
     <CodeSnippet v-else-if="section === 'with-caption'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableWithCaptionRaw"
                  :component="TableWithCaption"
     />
 
     <CodeSnippet v-else-if="section === 'with-footer'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableWithFooterRaw"
                  :component="TableWithFooter"
     />
 
     <CodeSnippet v-else-if="section === 'responsive'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="ResponsiveTableRaw"
                  :component="ResponsiveTable"
     />
 
     <CodeSnippet v-else-if="section === 'with-shadow'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableWithShadowRaw"
                  :component="TableWithShadow"
     />
 
     <CodeSnippet v-else-if="section === 'with-styled-header'"
-                 :id="section"
+                 :data-test-screenshot="section"
                  :code="TableWithStyledHeaderRaw"
                  :component="TableWithStyledHeader"
     />

--- a/packages/scripts/src/GenerateComponentsApi.ts
+++ b/packages/scripts/src/GenerateComponentsApi.ts
@@ -4,13 +4,13 @@ import { writeFile }                              from 'node:fs/promises';
 import * as path                                  from 'node:path';
 import { join, resolve }                          from 'node:path';
 import process                                    from 'node:process';
-import { fileURLToPath }                          from 'node:url';
 import glob                                       from 'fast-glob';
 import { createChecker }                          from 'vue-component-meta';
+import MonorepoPathResolver                       from './MonorepoPathResolver.ts';
 
 async function generateComponentsApi(): Promise<void> {
-    const packagesPath      = resolve(fileURLToPath(import.meta.url), '../../packages');
-    const corePath          = resolve(packagesPath, 'core');
+    const packagesPath      = MonorepoPathResolver.resolvePackagesPath();
+    const corePath          = MonorepoPathResolver.resolvePackagePath('core');
     const vueComponentsPath = resolve(corePath, 'src/Components');
 
     const checkerOptions: MetaCheckerOptions = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added an API section to Badge docs and enabled automatic API docs fallback within Badge examples.
  - Standardized CodeSnippet test hooks across the docs by replacing id with data-test-screenshot in multiple component guides (Buttons, Lists, Stats, Swap, Content, Forms, Navigation, Overlays, Tables).

- Refactor
  - Centralized monorepo path resolution in the API generation tooling to improve maintainability.

- Chores
  - Improved internal typing for Badge slots with no runtime impact.
  - Updated internal component naming to include an additional badge variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->