### PR TITLE
Refactor(FoSelect): Automatically inject null on UseSelectedOption if the type of the option id is nullable

### DIFF
--- a/packages/core/src/UI/Forms/Select/Lib/UseSelectedOption.ts
+++ b/packages/core/src/UI/Forms/Select/Lib/UseSelectedOption.ts
@@ -1,109 +1,57 @@
 import type { SelectOption, SelectOptionType }                                from '@/UI/Forms/Select';
-import type { ComputedRef, MaybeRefOrGetter, Ref, UnwrapRef }                 from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref }                            from 'vue';
 import { useIdentifiable }                                                    from '@/Lib/UseIdentifiable/Internal';
 import { isSelectOptionGroup }                                                from '@/UI/Forms/Select/Internal';
 import { computed, isReadonly, isRef, ref, toValue, watch, watchEffect      } from 'vue';
 
-export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
-    id: MaybeRefOrGetter<T | null>,
-): Ref<K | null>;
-
-export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
-    id: MaybeRefOrGetter<T>,
-    allowNull: false,
-): Ref<K>;
-
 /**
  * Retrieves the select option of a select field.
  *
+ * Inferred behavior:
+ * - If T includes `null` (e.g., Ref<number | null>), returns Ref<K | null>.
+ * - If T excludes `null` (e.g., Ref<number>), returns Ref<K> and throws if the id doesn't exist.
+ *
  * @param options
- * @param id The initial id of the option to retrieve, if it is a writable ref, the id will automatically be
- *           overridden with the selected option id when a new one is selected.
- * @param allowNull true if there can be a non-selected option, false otherwise.
+ * @param id The id of the option to retrieve; if it is a writable ref, it will be kept in sync
+ *           with the selected option id when a new one is selected.
  */
-export function useSelectedOption<T extends number | string, K extends SelectOption<T>>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
-    id: MaybeRefOrGetter<T | null> | MaybeRefOrGetter<T>,
-    allowNull: boolean = true,
-): Ref<K | null> | Ref<K> {
-    return isNullAllowed(id, allowNull)
-        ? useSelectedNullableOption(options, id)
-        : useSelectedNonNullableOption(options, id);
-}
-
-export function useSelectedNullableOption<T extends number | string, K extends SelectOption<T>>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
-    id: MaybeRefOrGetter<T | null>,
-): Ref<K | null> {
-    const flatOptions = getFlatOptions(options);
-
-    const selectedOption = useIdentifiable<'id', T, K>(flatOptions, id, 'id');
-
-    const option = ref<K | null>(null);
-
-    watch(selectedOption, () => option.value = selectedOption.value, { immediate: true });
-
-    watchEffect(() => {
-        if (isReadonly(id) === false && isRef(id)) {
-            (id as Ref<T | null>).value = option.value?.id ?? null;
-        }
-    });
-
-    return option as Ref<K | null>;
-}
-
-export function useSelectedNonNullableOption<T extends number | string, K extends SelectOption<T>>(
-    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<T, K>>[]>,
+export function useSelectedOption<
+    T extends number | string | null,
+    K extends SelectOption<NonNullable<T>>,
+>(
+    options: MaybeRefOrGetter<MaybeRefOrGetter<SelectOptionType<NonNullable<T>, K>>[]>,
     id: MaybeRefOrGetter<T>,
-): Ref<K> {
-    const flatOptions = getFlatOptions(options);
+): null extends T ? Ref<K | null> : Ref<K> {
+    const flatOptions = getFlatOptions<NonNullable<T>, K>(options);
 
-    const selectedOption = useIdentifiable<'id', T, K>(flatOptions, id, 'id');
+    const selectedOption = useIdentifiable<'id', NonNullable<T>, K>(
+        flatOptions,
+        id as MaybeRefOrGetter<NonNullable<T> | null>,
+        'id',
+    );
 
     const option = ref<K | null>(null);
 
     watch(
         selectedOption,
         () => {
-            option.value = getSelectedOptionIfExists(id, selectedOption).value;
+            // Non-nullable usage: id != null but option not found -> throw
+            if (selectedOption.value === null && toValue(id) !== null) {
+                throw new Error(`Selected option ${toValue(id)} does not exist.`);
+            }
+
+            option.value = selectedOption.value;
         },
         { immediate: true },
     );
 
     watchEffect(() => {
         if (isReadonly(id) === false && isRef(id)) {
-            (id as Ref<UnwrapRef<T>>).value = getSelectedOptionIfExists(id, option).value.id;
+            (id as Ref<NonNullable<T> | null>).value = option.value?.id ?? null;
         }
     });
 
-    return getSelectedOptionIfExists(id, option) as Ref<K>;
-}
-
-function isNullAllowed<T extends number | string>(
-    id: MaybeRefOrGetter<T | null> | MaybeRefOrGetter<T>,
-    allowNull: boolean,
-): id is MaybeRefOrGetter<T | null> {
-    return allowNull;
-}
-
-function guardAgainstNonExistingSelectedOption<T extends string | number>(
-    id: MaybeRefOrGetter<T>,
-    selectedOption: Ref<SelectOption<T> | null>,
-): asserts selectedOption is Ref<SelectOption<T>> {
-    if (selectedOption.value === null) {
-        throw new Error(`Selected option ${toValue(id)} does not exist.`);
-    }
-}
-
-function getSelectedOptionIfExists<T extends string | number, K extends SelectOption<T>>(
-    id: MaybeRefOrGetter<T>,
-    selectedOption: Ref<K | null>,
-): Ref<K> {
-    guardAgainstNonExistingSelectedOption(id, selectedOption);
-
-    return selectedOption;
+    return option as unknown as (null extends T ? Ref<K | null> : Ref<K>);
 }
 
 function getFlatOptions<T extends number | string, K extends SelectOption<T>>(

--- a/packages/docs/Forms/Select/DefaultSelect.vue
+++ b/packages/docs/Forms/Select/DefaultSelect.vue
@@ -25,6 +25,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption         = useSelectedOption<number, SelectOption>(options, 1, false);
-const selectedNullableOption = useSelectedOption(options, null);
+const selectedOption         = useSelectedOption<number, SelectOption>(options, 1);
+const selectedNullableOption = useSelectedOption<number | null, SelectOption>(options, null);
 </script>

--- a/packages/docs/Forms/Select/DefaultSelectSize.vue
+++ b/packages/docs/Forms/Select/DefaultSelectSize.vue
@@ -47,5 +47,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption<number | null, SelectOption>(options, null);
 </script>

--- a/packages/docs/Forms/Select/DisabledSelect.vue
+++ b/packages/docs/Forms/Select/DisabledSelect.vue
@@ -27,6 +27,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption         = useSelectedOption(options, null);
-const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption         = useSelectedOption<number | null, SelectOption>(options, null);
+const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectAsDatalist.vue
+++ b/packages/docs/Forms/Select/SelectAsDatalist.vue
@@ -20,5 +20,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: 'Chicago' },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption<number | null, SelectOption>(options, null);
 </script>

--- a/packages/docs/Forms/Select/SelectFloatingLabel.vue
+++ b/packages/docs/Forms/Select/SelectFloatingLabel.vue
@@ -19,5 +19,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectFloatingLabelSize.vue
+++ b/packages/docs/Forms/Select/SelectFloatingLabelSize.vue
@@ -47,5 +47,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectHiddenLabel.vue
+++ b/packages/docs/Forms/Select/SelectHiddenLabel.vue
@@ -25,5 +25,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectShape.vue
+++ b/packages/docs/Forms/Select/SelectShape.vue
@@ -39,6 +39,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption         = useSelectedOption(options, null);
-const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption         = useSelectedOption<number | null, SelectOption>(options, null);
+const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectValidationState.vue
+++ b/packages/docs/Forms/Select/SelectValidationState.vue
@@ -41,6 +41,6 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption         = useSelectedOption<number, SelectOption>(options, 1, false);
-const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption         = useSelectedOption<number, SelectOption>(options, 1);
+const selectedOptionFloating = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectWithIcon.vue
+++ b/packages/docs/Forms/Select/SelectWithIcon.vue
@@ -27,5 +27,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption(options, null);
+const selectedOption = useSelectedOption<number | null, SelectOption>(options, null);
 </script>

--- a/packages/docs/Forms/Select/SelectWithLabelAndHelperText.vue
+++ b/packages/docs/Forms/Select/SelectWithLabelAndHelperText.vue
@@ -20,5 +20,5 @@ const options = ref<SelectOption[]>([
     { id: 5, text: `Schindler's List` },
 ]);
 
-const selectedOption = useSelectedOption<number, SelectOption>(options, 1, false);
+const selectedOption = useSelectedOption<number, SelectOption>(options, 1);
 </script>

--- a/packages/docs/Forms/Select/SelectWithOptgroup.vue
+++ b/packages/docs/Forms/Select/SelectWithOptgroup.vue
@@ -7,9 +7,9 @@
 </template>
 
 <script setup lang="ts">
-import type { SelectOptionType }       from 'flyonui-vue';
-import { FoSelect, useSelectedOption } from 'flyonui-vue';
-import { ref }                         from 'vue';
+import type { SelectOption, SelectOptionType } from 'flyonui-vue';
+import { FoSelect, useSelectedOption }         from 'flyonui-vue';
+import { ref }                                 from 'vue';
 
 const options = ref<SelectOptionType[]>([
     {
@@ -30,5 +30,5 @@ const options = ref<SelectOptionType[]>([
     },
 ]);
 
-const selectedOption = useSelectedOption(options, 1, false);
+const selectedOption = useSelectedOption<number, SelectOption>(options, 1);
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified Select API: single signature now handles nullable and non‑nullable selections with clearer validation behavior.
- Refactor
  - Removed the extra boolean parameter; selection calls now use two arguments for simpler, more predictable usage.
- Documentation
  - Updated Select examples and demos to the new API, adding explicit generics for nullable numeric selections.
- Chores
  - Adjusted example imports to match the updated public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->