### PR TITLE
fix(core): Create vite plugin to allow core rebuild during props update in hmr

### DIFF
--- a/packages/core/vite.config.vue.mts
+++ b/packages/core/vite.config.vue.mts
@@ -1,9 +1,37 @@
+import type { Plugin }  from 'vite';
+import { exec }         from 'node:child_process';
+import * as fs          from 'node:fs';
 import { resolve }      from 'node:path';
 import process          from 'node:process';
 import tailwindcss      from '@tailwindcss/vite';
 import vue              from '@vitejs/plugin-vue';
 import { visualizer }   from 'rollup-plugin-visualizer';
 import { defineConfig } from 'vite';
+
+/**
+ * todo: maybe there is a better alternative to fix this.
+ *
+ * Vite/Rollup only rebuilds on changes to files that are part of the runtime dependency graph.
+ * The props come mainly from external files and are type-only imports,
+ * so they’re erased at compile time and don’t exist in the graph. This plugin rebuilds the package whenever a file
+ * contains props during hmr.
+ */
+function rebuildOnMaybePropsUpdate(): Plugin {
+    return {
+        name:        'rebuild-on-maybe-props-update',
+        apply:       'build',
+        watchChange: (file: string): void => {
+            if (file.endsWith('.ts')) {
+                const content = fs.readFileSync(file);
+
+                if (content.includes('Props')) {
+                    console.info(`File ${file} contains props. Rebuilding...`);
+                    exec('yarn build:vue:ui');
+                }
+            }
+        },
+    };
+}
 
 export default defineConfig({
     plugins: [
@@ -15,6 +43,7 @@ export default defineConfig({
                     filename: '../docs/public/build-size-visualizer.html',
                 })]
             : [],
+        rebuildOnMaybePropsUpdate(),
     ],
     resolve: {
         alias: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to automatically monitor and trigger rebuilds when relevant file changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->