### PR TITLE
feat(FoSelectThemeController): Capitalize theme names

### DIFF
--- a/packages/core/src/UI/Components/ThemeController/UI/FoSelectThemeController.vue
+++ b/packages/core/src/UI/Components/ThemeController/UI/FoSelectThemeController.vue
@@ -42,7 +42,7 @@ const props = withDefaults(defineProps<ThemeControllerProps & Omit<SelectProps<F
 
 const themeOptions = useArrayMap(() => Object.values(props.modes), (mode: FlyonUITheme) => ({
     id:   mode,
-    text: mode,
+    text: `${mode[0]?.toUpperCase()}${mode.slice(1)}`,
 }));
 
 const selectedTheme = useSelectedOption(themeOptions, useColorMode<FlyonUITheme>({ ...props }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme selector display formatting - theme mode names now appear with proper capitalization for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->