### PR TITLE
feat(docs): Integrate resizer component in ComponentPreview.vue and update layout

### DIFF
--- a/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
+++ b/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
@@ -20,6 +20,10 @@
                     Code
                 </FoTab>
 
+                <ComponentPreviewResizer v-model:size-class="sizeClass"
+                                         class="ms-auto"
+                />
+
                 <FoButtonGroup v-if="0 in codePreviews"
                                class="ms-auto"
                 >
@@ -37,9 +41,9 @@
             </template>
 
             <template #[`content-${previewTab.id}`]>
-                <div class="gap-4 bg-base-200/20 border-neutral/10 rounded-box not-prose w-full border p-3 sm:p-6 overflow-x-auto"
+                <div class="place-self-center gap-4 bg-base-200/20 border-neutral/10 rounded-box not-prose border p-3 sm:p-6 overflow-x-auto"
                      data-test="flyonui-vue-preview"
-                     :class="gridClass"
+                     :class="[sizeClass, gridClass]"
                      :dir="direction"
                 >
                     <ClientOnly>
@@ -67,6 +71,7 @@ import type { CodePreviewProps, ComponentPreviewProps } from '@/.vitepress/theme
 import type { Direction, TabProps }                     from 'flyonui-vue';
 import CodePreview
     from '@/.vitepress/theme/Components/Preview/UI/CodePreview.vue';
+import ComponentPreviewResizer from '@/.vitepress/theme/Components/Preview/UI/ComponentPreviewResizer.vue';
 import CopyButton
     from '@/.vitepress/theme/Components/Preview/UI/CopyButton.vue';
 import { FoButton, FoButtonGroup, FoTab, FoTabs, useFlyonUIVueAppConfig } from 'flyonui-vue';
@@ -75,6 +80,8 @@ import { computed, reactive, ref, useId, watch }                          from '
 const props = withDefaults(defineProps<ComponentPreviewProps>(), {
     grid: () => ({ columns: 0, rows: 0 }),
 });
+
+const sizeClass = ref<string>('');
 
 const id         = useId();
 const { config } = useFlyonUIVueAppConfig();

--- a/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreviewResizer.vue
+++ b/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreviewResizer.vue
@@ -1,0 +1,72 @@
+<template>
+    <FoButtonGroup v-if="sizes.tablet !== undefined">
+        <FoButton v-for="({ icon }, device) in sizes"
+                  :key="device"
+                  :title="device"
+                  :color="device === currentDevice ? 'primary' : 'neutral'"
+                  preset="gradient"
+                  :icon="icon"
+                  @click.prevent="updateSize(device)"
+        />
+    </FoButtonGroup>
+</template>
+
+<script setup lang="ts">
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core';
+import { FoButton, FoButtonGroup }             from 'flyonui-vue';
+import { computed, onMounted, ref, watch }     from 'vue';
+
+const sizeClass = defineModel<string>('sizeClass', { required: true });
+
+type Device = 'desktop' | 'laptop' | 'tablet' | 'phone';
+
+interface DeviceData {
+    size: string;
+    icon: string;
+}
+
+const currentDevice = ref<Device>('desktop');
+const { greater }   = useBreakpoints(breakpointsTailwind);
+
+const sizes = computed((): Record<Device, DeviceData> => {
+    const devices: Record<Device, DeviceData> = {} as Record<Device, DeviceData>;
+    let last: DeviceData | null               = null;
+
+    // There is no xs in the breakpoints, so I use sm as the smallest one
+    if (greater('sm').value) {
+        last = devices.phone = { size: 'w-xs', icon: 'tabler:device-mobile' };
+    }
+
+    if (greater('xl').value) {
+        last = devices.tablet = { size: 'w-xl', icon: 'tabler:device-tablet' };
+    }
+
+    if (greater('2xl').value) {
+        last = devices.laptop = { size: 'w-3xl', icon: 'tabler:device-laptop' };
+        last = devices.desktop = { size: 'w-full', icon: 'tabler:device-desktop' };
+    }
+
+    // The last should always be the one matching the active breakpoint, so we use w-full
+    if (last !== null) {
+        last.size = 'w-full';
+    }
+
+    return devices;
+});
+
+const currentSizeClass = computed((): string => sizes.value[currentDevice.value]?.size ?? '');
+const lastDevice       = computed((): Device => (Object.keys(sizes.value).at(-1) ?? 'desktop') as Device);
+
+onMounted((): void => updateSize(lastDevice.value));
+
+watch(
+    sizes,
+    (): void => updateSize(lastDevice.value),
+    { deep: true },
+);
+
+function updateSize(device: Device): void {
+    currentDevice.value = device;
+    sizeClass.value = currentSizeClass.value;
+}
+</script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resizable preview component with device size selector. Users can now switch between different screen sizes (phone, tablet, laptop, desktop) when viewing component previews in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->