### PR TITLE
feat(types)!: rename Animation type to LoadingAnimation for clarity

### DIFF
--- a/packages/core/src/UI/Components/Loading/Types/Loading.ts
+++ b/packages/core/src/UI/Components/Loading/Types/Loading.ts
@@ -1,8 +1,8 @@
 import type { Colorable, Sizable  } from '@/Lib';
 
-export type Animation = 'spinner' | 'dots' | 'ring' | 'ball' | 'bars' | 'infinity';
+export type LoadingAnimation = 'spinner' | 'dots' | 'ring' | 'ball' | 'bars' | 'infinity';
 
 export interface LoadingProps extends Colorable, Sizable {
     /** The component's loading animation */
-    animation?: Animation;
+    animation?: LoadingAnimation;
 }

--- a/packages/core/src/UI/Components/Loading/UI/FoLoading.vue
+++ b/packages/core/src/UI/Components/Loading/UI/FoLoading.vue
@@ -9,12 +9,12 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentName }           from '@/Lib';
-import type { Animation, LoadingProps } from '@/UI/Components';
-import { useFlyonUIVueAppConfig }       from '@/Lib';
-import { useTextColor }                 from '@/Lib/UseColor/Internal';
-import { useSize }                      from '@/Lib/UseSize/Internal';
-import { computed }                     from 'vue';
+import type { ComponentName }                  from '@/Lib';
+import type { LoadingAnimation, LoadingProps } from '@/UI/Components';
+import { useFlyonUIVueAppConfig }              from '@/Lib';
+import { useTextColor }                        from '@/Lib/UseColor/Internal';
+import { useSize }                             from '@/Lib/UseSize/Internal';
+import { computed }                            from 'vue';
 
 const props = withDefaults(defineProps<LoadingProps>(), {
     animation: 'spinner',
@@ -25,7 +25,7 @@ const componentName: ComponentName = 'FoLoading';
 const { config } = useFlyonUIVueAppConfig();
 
 const animationClass = computed(() => {
-    const icons: Record<Animation, string> = {
+    const icons: Record<LoadingAnimation, string> = {
         spinner:  'loading-spinner',
         dots:     'loading-dots',
         ring:     'loading-ring',

--- a/packages/docs/UpgradeGuide.md
+++ b/packages/docs/UpgradeGuide.md
@@ -10,6 +10,7 @@ The minimum required version for Node.js is now `>= 20.19.0`.
 
 - The `Direction` type has been renamed to `TextDirection`.
 - The property `direction` of the type `FlyonUIVueAppGlobalConfig` has been renamed to `textDirection`.
+- The `Animation` type has been renamed to `LoadingAnimation`.
 
 ### All Components - Props
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `Animation` type has been renamed to `LoadingAnimation` for consistency.

* **Documentation**
  * Updated the upgrade guide to reflect the type name change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->