### PR TITLE
refactor(docs): Rename lang prop to language in ComponentPreview.vue

### DIFF
--- a/packages/docs/.vitepress/theme/Components/Preview/Types/Preview.ts
+++ b/packages/docs/.vitepress/theme/Components/Preview/Types/Preview.ts
@@ -19,7 +19,7 @@ export interface ComponentPreviewProps {
 }
 
 export interface CodePreviewProps {
-    title?: string;
-    code:   string;
-    lang:   string;
+    title?:   string;
+    code:     string;
+    language: string;
 }

--- a/packages/docs/.vitepress/theme/Components/Preview/UI/CodePreview.vue
+++ b/packages/docs/.vitepress/theme/Components/Preview/UI/CodePreview.vue
@@ -16,7 +16,7 @@
             />
         </FoButtonGroup>
 
-        <CodeSnippet :language="lang"
+        <CodeSnippet :language="language"
                      :code="code"
         />
     </div>
@@ -37,6 +37,6 @@ const CodeSnippet = plugin.component;
 @reference "tailwindcss";
 
 .hljs {
-    @apply rounded-b-lg text-[16px]! max-h-[500px];
+    @apply rounded-b-lg text-[16px]! max-h-125;
 }
 </style>

--- a/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
+++ b/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
@@ -58,7 +58,7 @@
                                  :key="codePreview.code"
                                  :title="codePreview.title"
                                  :code="codePreview.code"
-                                 :lang="codePreview.lang"
+                                 :language="codePreview.language"
                     />
                 </div>
             </template>
@@ -102,10 +102,10 @@ const isLtr = computed(() => direction.value === 'ltr');
 
 const codePreviews = computed((): CodePreviewProps[] => {
     if (typeof props.code === 'string') {
-        return [{ title: 'Vue', code: props.code, lang: 'js' }];
+        return [{ title: 'Vue', code: props.code, language: 'js' }];
     }
 
-    return props.code.map(c => ({ ...c, lang: 'js' }));
+    return props.code.map(c => ({ ...c, language: 'js' }));
 });
 
 const gridClass = computed(() => {

--- a/packages/docs/QuickStart.md
+++ b/packages/docs/QuickStart.md
@@ -7,7 +7,7 @@
 If you are starting a new `Vite` + `Vue` project you can use our automatic flyonui-vue installation tool 
 [create-flyonui-vue](https://github.com/michaelcozzolino/flyonui-vue/blob/2.x/packages/create-flyonui-vue/README.md):
 
-<CodePreview lang="bash"
+<CodePreview language="bash"
              code="yarn create flyonui-vue"
 />
 
@@ -18,31 +18,31 @@ and [Tailwind CSS](https://tailwindcss.com/) installed.
 
 1. Install `flyonui-vue` as a dependency using NPM or Yarn by running the following command:
 
-<CodePreview lang="bash" 
+<CodePreview language="bash" 
              code="npm i flyonui-vue"
 />
 
 or
 
-<CodePreview lang="bash"
+<CodePreview language="bash"
              code="yarn add flyonui-vue"
 />
 
 in order to use icons, `@iconify/vue` is required:
 
-<CodePreview lang="bash"
+<CodePreview language="bash"
              code="yarn add @iconify/vue"
 />
 
 2. Import styles:
 
-<CodePreview lang="css"
+<CodePreview language="css"
              code="@import 'flyonui-vue/index.css';"
 />
 
 3. source the tailwind components' classes:
 
-<CodePreview lang="css"
+<CodePreview language="css"
              code="@source '../../node_modules/flyonui-vue';"
 />
 
@@ -65,14 +65,14 @@ components supporting them, except that the `FoButton.vue` will have a `large` s
 for example:
 
 <CodePreview title="CustomButton.vue"
-             lang="js"
+             language="js"
              code="<FoButton>Large Accent Button</FoButton>"
 />
 
 <br>
 
 <CodePreview title="CustomBadge.vue"
-             lang="js"
+             language="js"
              code="<FoBadge>Small Info Badge</FoBadge>"
 />
 
@@ -92,7 +92,7 @@ A Vue Ref is exposed and can be manipulated on demand based on your desired beha
 All you need to do is to use the composable:
 
 <CodePreview title="Vue"
-             lang="js"
+             language="js"
              code="const config = useFlyonUIVueAppConfig();"
 />
 
@@ -100,6 +100,6 @@ if you want to be able to manipulate the configuration, where the initial one is
 use the plugin:
 
 <CodePreview title="App.ts"
-             lang="js"
+             language="js"
              code="app.use(createFlyonUIVueApp, {});"
 />

--- a/packages/docs/QuickStart/CreateFlyonUIVueApp/CreateFlyonUIVueAppDocs.vue
+++ b/packages/docs/QuickStart/CreateFlyonUIVueApp/CreateFlyonUIVueAppDocs.vue
@@ -1,6 +1,6 @@
 <template>
     <CodePreview title="TS"
-                 lang="ts"
+                 language="ts"
                  :code="ConfigurationExampleRaw.replace('// @ts-expect-error E.G', '')"
     />
 </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced the maximum display height for code preview panels to improve vertical layout and visual presentation.

* **Refactor**
  * Updated the code preview attribute used to specify the language across docs and preview components for consistent usage (no functional change to rendering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->