### PR TITLE
fix(docs): Use window only when defined

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
         "@vueuse/core": "^14.2.1",
         "@vueuse/motion": "^3.0.3",
         "deepmerge": "^4.3.1",
-        "unhead": "^2.1.4"
+        "unhead": "^2.1.12"
     },
     "devDependencies": {
         "@iconify/vue": "^4.3.0",

--- a/packages/docs/.vitepress/theme/Components/Layout/Lib/UseAnchorScrollSpy.ts
+++ b/packages/docs/.vitepress/theme/Components/Layout/Lib/UseAnchorScrollSpy.ts
@@ -1,8 +1,8 @@
-import type { useRouter }        from 'vitepress';
-import type { Ref }              from 'vue';
-import { useEventListener }      from '@vueuse/core';
-import { getScrollOffset }       from 'vitepress';
-import { onMounted, ref, watch } from 'vue';
+import type { useRouter }             from 'vitepress';
+import type { Ref }                   from 'vue';
+import { isClient, useEventListener } from '@vueuse/core';
+import { getScrollOffset }            from 'vitepress';
+import { onMounted, ref, watch }      from 'vue';
 
 interface ResolvedHeader {
     element: HTMLElement;
@@ -20,6 +20,10 @@ export function useAnchorScrollSpy(
     docsHeadings: Ref<NodeListOf<HTMLElement> | null>,
     router: ReturnType<typeof useRouter>,
 ): void {
+    if (isClient === false) {
+        return;
+    }
+
     useEventListener(window, 'scroll', setActiveHash, { passive: true });
 
     const resolvedHeaders = ref<ResolvedHeader[]>([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,7 +5215,7 @@ __metadata:
     tailwindcss: "npm:^4.1.18"
     tsc-alias: "npm:^1.8.16"
     typescript: "npm:^5.9.3"
-    unhead: "npm:^2.1.4"
+    unhead: "npm:^2.1.12"
     vite: "npm:^6.4.1"
     vue: "npm:^3.5.28"
     vue-router: "npm:^4.6.4"
@@ -9172,12 +9172,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unhead@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "unhead@npm:2.1.4"
+"unhead@npm:^2.1.12":
+  version: 2.1.12
+  resolution: "unhead@npm:2.1.12"
   dependencies:
     hookable: "npm:^6.0.1"
-  checksum: 10c0/084f28b40e9b918ff43fff03f64ff5c3aa28341795d4b139218a58063b7c9f7c94892aaddcd0951d32dd04113f9781eb95e5c02e51fa7ecb3e2e51c56e146d28
+  checksum: 10c0/fb5afcab73ea28176f854462e976f5f953e995563f3d9c7e5af42259af5fe1cbbc3111e54118e932c9d2673d641dd2f0c59656c9cc3e34505d2322564cfcd0e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented anchor scroll listener from initializing during server-side rendering by adding an environment check.

* **Refactor**
  * Improved scroll-tracking setup for more reliable behavior across server and client execution contexts.

* **Chores**
  * Updated an internal dependency to a newer patch release for dependency maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->