### PR TITLE
fix(docs): Load docs together with headers, feat(docs): Add spinner when loading website for the first time

### DIFF
--- a/packages/docs/.vitepress/theme/Components/Layout/Features/Navbar/UI/Navbar.vue
+++ b/packages/docs/.vitepress/theme/Components/Layout/Features/Navbar/UI/Navbar.vue
@@ -56,13 +56,13 @@
 import type { FlyonUITheme, NavbarLink } from 'flyonui-vue';
 import ConfigurationSettings
     from '@/.vitepress/theme/Components/ConfigurationSettings/UI/ConfigurationSettings.vue';
-import { useLayoutStore } from '@/.vitepress/theme/Components/Layout/Lib/UseLayoutStore';
+import {
+    useLayoutStore,
+}                                                                             from '@/.vitepress/theme/Components/Layout/Lib/UseLayoutStore';
+import { useColorMode, useStorage } from '@vueuse/core';
 
-import { loadIcons }                                                          from '@iconify/vue';
-import { useColorMode, useStorage }                                           from '@vueuse/core';
 import { FoButton, FoLink, FoModal, FoNavbar, FoNavbarBrand, FoSocialButton } from 'flyonui-vue';
-import { storeToRefs }                                                        from 'pinia';
-import { useData, useRouter, withBase }                                       from 'vitepress';
+import { useRouter, withBase }                                                from 'vitepress';
 import { VPNavBarSearch }                                                     from 'vitepress/theme';
 import { computed, onMounted, ref }                                           from 'vue';
 
@@ -70,9 +70,7 @@ const flyonUIVueVersion = FLYONUI_VUE_VERSION;
 
 const router = useRouter();
 
-const { page }                                         = useData();
-const { isNotHomepage, vitepressThemeLocalStorageKey } = useLayoutStore();
-const { isSidebarCollapsed }                           = storeToRefs(useLayoutStore());
+const { vitepressThemeLocalStorageKey } = useLayoutStore();
 
 const links = computed((): NavbarLink[] => {
     return [
@@ -106,20 +104,5 @@ onMounted(() => {
         mergeDefaults: true,
         storageKey:    themeStorageKey,
     });
-
-    loadIcons([
-        'tabler:layout-sidebar-left-collapse-filled',
-        'tabler:layout-sidebar-right-collapse-filled',
-        'radix-icons:dimensions',
-        'la:border-style',
-        'fluent:color-20-regular',
-        'fluent:shapes-20-regular',
-        'fluent:text-direction-horizontal-ltr-20-regular',
-        'fluent:text-direction-horizontal-rtl-20-regular',
-        'ep:select',
-        'tabler:chevron-left',
-        'tabler:chevron-right',
-        'tabler:dots',
-    ]);
 });
 </script>

--- a/packages/docs/.vitepress/theme/Components/Layout/Features/Sidebar/UI/Sidebar.vue
+++ b/packages/docs/.vitepress/theme/Components/Layout/Features/Sidebar/UI/Sidebar.vue
@@ -6,7 +6,7 @@
                :class="[
                    isCollapsed ? 'w-24' : 'w-64',
                    isPageSizeSmallerThanSm && 'fixed! z-1 overflow-x-hidden top-20 transition-[width]',
-                   showMenu && 'bg-base-100'
+                   showMenu && 'bg-base-100',
                ]"
                tabindex="-1"
         >
@@ -110,7 +110,7 @@ onClickOutside(
     { ignore: ['.flyonui-vue-navbar-collapse'] },
 );
 
-watch(activeItemId, scrollToActiveItem, { immediate: true });
+watch(activeItemId, scrollToActiveItem);
 
 async function scrollToActiveItem(): Promise<void> {
     // We should wait for the active item id to be populated after its component has been mounted

--- a/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
+++ b/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
@@ -1,0 +1,77 @@
+import type { AsyncComponentLoader, Component } from 'vue';
+import { defineAsyncComponent, ref }            from 'vue';
+
+/**
+ * Knowing that te docs components are lazily loaded to split the bundle in small chunks, in order to load the
+ * components example together with the Markdown headers, we need to know when all the registered asynchronous
+ * components have been resolved, when true the final content is ready to be shown, otherwise, it must still wait.
+ */
+export const isDocsPageReady            = ref<boolean>(false);
+export const pendingAsyncComponentCount = ref<number>(0);
+
+let readyTimeoutId: number | null = null;
+
+/**
+ * Wraps docs and similar async components so the page is revealed
+ * only after all markdown-mounted async blocks have resolved.
+ */
+export function defineAsyncDocsComponent<T extends Component>(component: AsyncComponentLoader<T>): T {
+    return defineAsyncComponent(trackAsyncDocsComponent(component));
+}
+
+/**
+ * Tracks pending async docs component loads and mark the docs page as ready once the last one finishes.
+ */
+function trackAsyncDocsComponent<T extends Component>(component: AsyncComponentLoader<T>): AsyncComponentLoader<T> {
+    return async () => {
+        clearReadyTimeout();
+        pendingAsyncComponentCount.value += 1;
+        console.warn('pend', pendingAsyncComponentCount.value);
+
+        return await component().finally(() => {
+            pendingAsyncComponentCount.value = Math.max(0, pendingAsyncComponentCount.value - 1);
+
+            if (pendingAsyncComponentCount.value === 0) {
+                markDocsPageAsReady();
+            }
+        });
+    };
+}
+
+/**
+ * Cancels a previously scheduled ready commit when a new async load starts or the page state resets.
+ */
+function clearReadyTimeout(): void {
+    if (readyTimeoutId === null) {
+        return;
+    }
+
+    clearTimeout(readyTimeoutId);
+    readyTimeoutId = null;
+}
+
+/**
+ * Defers the ready flag to the next macrotask so new async loads can invalidate it before the page is revealed.
+ */
+export function markDocsPageAsReady(): void {
+    clearReadyTimeout();
+
+    if (pendingAsyncComponentCount.value > 0) {
+        return;
+    }
+
+    readyTimeoutId = window.setTimeout(() => {
+        if (pendingAsyncComponentCount.value === 0) {
+            isDocsPageReady.value = true;
+        }
+    }, 0);
+}
+
+/**
+ * Resets the docs page readiness on navigation before the next page's async Markdown components begin loading.
+ */
+export function resetDocsPageAsyncState(): void {
+    pendingAsyncComponentCount.value = 0;
+    isDocsPageReady.value = false;
+    clearReadyTimeout();
+}

--- a/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
+++ b/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
@@ -26,11 +26,6 @@ function trackAsyncDocsComponent<T extends Component>(component: AsyncComponentL
     return async () => {
         clearReadyTimeout();
         pendingAsyncComponentCount.value += 1;
-     return async () => {
-         clearReadyTimeout();
-         pendingAsyncComponentCount.value += 1;
-
-         return await component().finally(() => {
 
         return await component().finally(() => {
             pendingAsyncComponentCount.value = Math.max(0, pendingAsyncComponentCount.value - 1);

--- a/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
+++ b/packages/docs/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent.ts
@@ -26,7 +26,11 @@ function trackAsyncDocsComponent<T extends Component>(component: AsyncComponentL
     return async () => {
         clearReadyTimeout();
         pendingAsyncComponentCount.value += 1;
-        console.warn('pend', pendingAsyncComponentCount.value);
+     return async () => {
+         clearReadyTimeout();
+         pendingAsyncComponentCount.value += 1;
+
+         return await component().finally(() => {
 
         return await component().finally(() => {
             pendingAsyncComponentCount.value = Math.max(0, pendingAsyncComponentCount.value - 1);

--- a/packages/docs/.vitepress/theme/Components/Layout/UI/Layout.vue
+++ b/packages/docs/.vitepress/theme/Components/Layout/UI/Layout.vue
@@ -1,112 +1,18 @@
 <template>
-    <div>
-        <Navbar />
-        <main class="main">
-            <template v-if="page.isNotFound">
-                <NotFound />
-            </template>
+    <suspense>
+        <SuspensibleLayout />
 
-            <Home v-else-if="isHomepage()" />
-
-            <div v-else
-                 class="flex"
-            >
-                <Sidebar />
-
-                <Content class="VPDoc vp-doc flex-grow m-8 min-w-0" />
-
-                <DocsSidebar v-if="frontmatter.aside !== false && items.length"
-                             :items="items"
+        <template #fallback>
+            <div class="flex min-h-screen items-center justify-center">
+                <FoLoading color="primary"
+                           size="extraLarge"
                 />
             </div>
-        </main>
-    </div>
+        </template>
+    </suspense>
 </template>
 
 <script setup lang="ts">
-import type { DocsSidebarItem } from '@/.vitepress/theme/Components/Layout/Features/DocsSidebar/Types/DocsSidebar.ts';
-
-import type { FlyonUITheme } from 'flyonui-vue';
-import DocsSidebar           from '@/.vitepress/theme/Components/Layout/Features/DocsSidebar/UI/DocsSidebar.vue';
-import Home                  from '@/.vitepress/theme/Components/Layout/Features/Home/UI/Home.vue';
-import Navbar                from '@/.vitepress/theme/Components/Layout/Features/Navbar/UI/Navbar.vue';
-
-import NotFound
-    from '@/.vitepress/theme/Components/Layout/Features/NotFound/UI/NotFound.vue';
-import Sidebar
-    from '@/.vitepress/theme/Components/Layout/Features/Sidebar/UI/Sidebar.vue';
-import {
-    useAnchorScrollSpy,
-}                                                        from '@/.vitepress/theme/Components/Layout/Lib/UseAnchorScrollSpy';
-import { useLayoutStore }                                from '@/.vitepress/theme/Components/Layout/Lib/UseLayoutStore';
-import { useColorMode }                                  from '@vueuse/core';
-import { useFlyonUIThemeFont }                           from 'flyonui-vue';
-import { Content, onContentUpdated, useData, useRouter } from 'vitepress';
-import { computed, onMounted, ref }                      from 'vue';
-
-const router = useRouter();
-
-const { isHomepage, vitepressThemeLocalStorageKey } = useLayoutStore();
-const { frontmatter, page }                         = useData();
-
-const docsHeadings = ref<NodeListOf<HTMLElement> | null>(null);
-
-useAnchorScrollSpy(docsHeadings, router);
-
-const items = computed((): DocsSidebarItem[] => {
-    if (docsHeadings.value === null) {
-        return [];
-    }
-
-    const roots: DocsSidebarItem[] = [];
-    const stack: DocsSidebarItem[] = [];
-
-    for (let i = 0; i < docsHeadings.value.length; i++) {
-        const heading = docsHeadings.value.item(i);
-
-        if (heading === null) {
-            continue;
-        }
-
-        const level = Number(heading.tagName[1]);
-
-        const anchor = heading.querySelector<HTMLAnchorElement>('a.header-anchor');
-
-        if (anchor === null) {
-            continue;
-        }
-
-        const item: DocsSidebarItem = {
-            id:       i,
-            to:       `${anchor.pathname}${anchor.hash}`,
-            text:     heading.textContent ?? '',
-            children: [],
-            level,
-        };
-
-        // Pop the stack until we find a parent with a lower level
-        while (stack.length && Number(stack.at(-1)?.level) >= level) {
-            stack.pop();
-        }
-
-        if (stack.length === 0) {
-            roots.push(item);
-        } else {
-            stack.at(-1)?.children.push(item);
-        }
-
-        stack.push(item);
-    }
-
-    return roots;
-});
-
-onContentUpdated(() => {
-    docsHeadings.value = document.querySelectorAll('.VPDoc :where(h1,h2,h3,h4,h5,h6)');
-});
-
-onMounted(() => useFlyonUIThemeFont(
-    useColorMode<FlyonUITheme>({ storageKey: vitepressThemeLocalStorageKey }),
-    '--vp-font-family-base',
-));
+import SuspensibleLayout from '@/.vitepress/theme/Components/Layout/UI/SuspensibleLayout.vue';
+import { FoLoading }     from 'flyonui-vue';
 </script>

--- a/packages/docs/.vitepress/theme/Components/Layout/UI/SuspensibleLayout.vue
+++ b/packages/docs/.vitepress/theme/Components/Layout/UI/SuspensibleLayout.vue
@@ -1,0 +1,165 @@
+<template>
+    <div>
+        <Navbar />
+
+        <main class="main">
+            <template v-if="page.isNotFound">
+                <NotFound />
+            </template>
+
+            <Home v-else-if="isHomepage()" />
+
+            <div v-else
+                 class="flex"
+            >
+                <Sidebar />
+
+                <div v-show="isDocsPageReady"
+                     class="flex w-full"
+                >
+                    <Content class="VPDoc vp-doc grow m-8 min-w-0" />
+
+                    <DocsSidebar v-if="frontmatter.aside !== false && items.length"
+                                 :items="items"
+                    />
+                </div>
+            </div>
+        </main>
+    </div>
+</template>
+
+<script setup lang="ts">
+import type { DocsSidebarItem } from '@/.vitepress/theme/Components/Layout/Features/DocsSidebar/Types/DocsSidebar.ts';
+
+import type { FlyonUITheme } from 'flyonui-vue';
+import DocsSidebar           from '@/.vitepress/theme/Components/Layout/Features/DocsSidebar/UI/DocsSidebar.vue';
+import Home                  from '@/.vitepress/theme/Components/Layout/Features/Home/UI/Home.vue';
+import Navbar                from '@/.vitepress/theme/Components/Layout/Features/Navbar/UI/Navbar.vue';
+
+import NotFound
+    from '@/.vitepress/theme/Components/Layout/Features/NotFound/UI/NotFound.vue';
+import Sidebar
+    from '@/.vitepress/theme/Components/Layout/Features/Sidebar/UI/Sidebar.vue';
+import {
+    isDocsPageReady,
+    markDocsPageAsReady,
+    pendingAsyncComponentCount,
+    resetDocsPageAsyncState,
+}                                                        from '@/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent';
+import {
+    useAnchorScrollSpy,
+}                                                        from '@/.vitepress/theme/Components/Layout/Lib/UseAnchorScrollSpy';
+import { useLayoutStore }                                from '@/.vitepress/theme/Components/Layout/Lib/UseLayoutStore';
+import { useColorMode }                                  from '@vueuse/core';
+import { useFlyonUIThemeFont }                           from 'flyonui-vue';
+import { Content, onContentUpdated, useData, useRouter } from 'vitepress';
+import { computed, nextTick, onMounted, ref, watch }     from 'vue';
+
+const router = useRouter();
+
+const { isHomepage, vitepressThemeLocalStorageKey } = useLayoutStore();
+const { frontmatter, page }                         = useData();
+
+const docsHeadings = ref<NodeListOf<HTMLElement> | null>(null);
+
+useAnchorScrollSpy(docsHeadings, router);
+
+const items = computed((): DocsSidebarItem[] => {
+    if (docsHeadings.value === null) {
+        return [];
+    }
+
+    const roots: DocsSidebarItem[] = [];
+    const stack: DocsSidebarItem[] = [];
+
+    for (let i = 0; i < docsHeadings.value.length; i++) {
+        const heading = docsHeadings.value.item(i);
+
+        if (heading === null) {
+            continue;
+        }
+
+        const level = Number(heading.tagName[1]);
+
+        const anchor = heading.querySelector<HTMLAnchorElement>('a.header-anchor');
+
+        if (anchor === null) {
+            continue;
+        }
+
+        const item: DocsSidebarItem = {
+            id:       i,
+            to:       `${anchor.pathname}${anchor.hash}`,
+            text:     heading.textContent ?? '',
+            children: [],
+            level,
+        };
+
+        // Pop the stack until we find a parent with a lower level
+        while (stack.length && Number(stack.at(-1)?.level) >= level) {
+            stack.pop();
+        }
+
+        if (stack.length === 0) {
+            roots.push(item);
+        } else {
+            stack.at(-1)?.children.push(item);
+        }
+
+        stack.push(item);
+    }
+
+    return roots;
+});
+
+onMounted(async () => {
+    useFlyonUIThemeFont(
+        useColorMode<FlyonUITheme>({ storageKey: vitepressThemeLocalStorageKey }),
+        '--vp-font-family-base',
+    );
+});
+
+watch(() => router.route.path, () => {
+    resetDocsPageAsyncState();
+}, { immediate: true });
+
+watch(isDocsPageReady, async () => {
+    if (isDocsPageReady.value === false) {
+        return;
+    }
+
+    await nextTick();
+
+    docsHeadings.value = document.querySelectorAll('.VPDoc :where(h1,h2,h3,h4,h5,h6)');
+
+    /**
+     * Due to the loader, if the route has a hash the scroll gets lost, so we do a manual scroll to the current hash.
+     * When changing page, there will be no hash so the callback will exit early.
+     */
+    requestAnimationFrame(() => {
+        const hash = router.route.hash;
+
+        if (hash === '') {
+            return;
+        }
+
+        const targetElement = document.getElementById(decodeURIComponent(hash.slice(1)));
+
+        if (targetElement === null) {
+            return;
+        }
+
+        targetElement.scrollIntoView({ behavior: 'smooth' });
+    });
+});
+
+onContentUpdated(() => {
+    docsHeadings.value = document.querySelectorAll('.VPDoc :where(h1,h2,h3,h4,h5,h6)');
+
+    nextTick(() => {
+        if (pendingAsyncComponentCount.value === 0) {
+            markDocsPageAsReady();
+        }
+    });
+});
+</script>

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -3,14 +3,16 @@ import type { Theme } from 'vitepress';
 import type { App, Component }             from 'vue';
 import ComponentNotReadyForProductionAlert
     from '@/.vitepress/theme/Components/ComponentDocs/UI/ComponentNotReadyForProductionAlert.vue';
-import TipAlert                                                            from '@/.vitepress/theme/Components/ComponentDocs/UI/TipAlert.vue';
-import Layout                                                              from '@/.vitepress/theme/Components/Layout/UI/Layout.vue';
+import TipAlert                     from '@/.vitepress/theme/Components/ComponentDocs/UI/TipAlert.vue';
+import { defineAsyncDocsComponent } from '@/.vitepress/theme/Components/Layout/Lib/defineAsyncDocsComponent';
+import Layout
+    from '@/.vitepress/theme/Components/Layout/UI/Layout.vue';
 import CodePreview                                                         from '@/.vitepress/theme/Components/Preview/UI/CodePreview.vue';
 import hljsVuePlugin                                                       from '@highlightjs/vue-plugin';
+import { loadIcons }                                                       from '@iconify/vue';
 import { createFlyonUIVueApp, FoKeyboard, FoSelectThemeController, vMask } from 'flyonui-vue';
 import { createPinia }                                                     from 'pinia';
 import DefaultTheme                                                        from 'vitepress/theme';
-import { defineAsyncComponent }                                            from 'vue';
 import './index.css';
 import 'highlight.js/styles/github-dark-dimmed.css';
 import 'highlight.js/lib/common';
@@ -51,15 +53,15 @@ export default {
         registerDocComponents(app, [
             {
                 name:      'AvatarDocs',
-                component: defineAsyncComponent(() => import('@/Components/Avatar/AvatarDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Avatar/AvatarDocs.vue')),
             },
             {
                 name:      'KeyboardDocs',
-                component: defineAsyncComponent(() => import('@/Content/Keyboard/KeyboardDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/Keyboard/KeyboardDocs.vue')),
             },
             {
                 name:      'AlertDocs',
-                component: defineAsyncComponent(() => import('@/Components/Alert/AlertDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Alert/AlertDocs.vue')),
             },
             {
                 name:      'ComponentNotReadyForProductionAlert',
@@ -71,139 +73,139 @@ export default {
             },
             {
                 name:      'LinkDocs',
-                component: defineAsyncComponent(() => import('@/Content/Link/LinkDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/Link/LinkDocs.vue')),
             },
             {
                 name:      'BadgeDocs',
-                component: defineAsyncComponent(() => import('@/Components/Badge/BadgeDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Badge/BadgeDocs.vue')),
             },
             {
                 name:      'BlockQuoteDocs',
-                component: defineAsyncComponent(() => import('@/Content/BlockQuote/BlockQuoteDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/BlockQuote/BlockQuoteDocs.vue')),
             },
             {
                 name:      'ButtonDocs',
-                component: defineAsyncComponent(() => import('@/Components/Button/ButtonDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Button/ButtonDocs.vue')),
             },
             {
                 name:      'CheckboxDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Checkbox/CheckboxDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Checkbox/CheckboxDocs.vue')),
             },
             {
                 name:      'DataTableDocs',
-                component: defineAsyncComponent(() => import('@/Tables/DataTable/DataTableDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Tables/DataTable/DataTableDocs.vue')),
             },
             {
                 name:      'DiffDocs',
-                component: defineAsyncComponent(() => import('@/Components/Diff/DiffDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Diff/DiffDocs.vue')),
             },
             {
                 name:      'DividerDocs',
-                component: defineAsyncComponent(() => import('@/Content/Divider/DividerDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/Divider/DividerDocs.vue')),
             },
             {
                 name:      'InputFileDocs',
-                component: defineAsyncComponent(() => import('@/Forms/InputFile/InputFileDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/InputFile/InputFileDocs.vue')),
             },
             {
                 name:      'InputTextDocs',
-                component: defineAsyncComponent(() => import('@/Forms/InputText/InputTextDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/InputText/InputTextDocs.vue')),
             },
             {
                 name:      'IconsDocs',
-                component: defineAsyncComponent(() => import('@/Customisation/Icons/IconsDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Customisation/Icons/IconsDocs.vue')),
             },
             {
                 name:      'JoinDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Join/JoinDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Join/JoinDocs.vue')),
             },
             {
                 name:      'LoadingDocs',
-                component: defineAsyncComponent(() => import('@/Components/Loading/LoadingDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Loading/LoadingDocs.vue')),
             },
             {
                 name:      'ListGroupDocs',
-                component: defineAsyncComponent(() => import('@/Components/ListGroup/ListGroupDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/ListGroup/ListGroupDocs.vue')),
             },
             {
                 name:      'MaskDocs',
-                component: defineAsyncComponent(() => import('@/Content/Mask/MaskDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/Mask/MaskDocs.vue')),
             },
             {
                 name:      'HeadingDocs',
-                component: defineAsyncComponent(() => import('@/Content/Heading/HeadingDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Content/Heading/HeadingDocs.vue')),
             },
             {
                 name:      'MenuDocs',
-                component: defineAsyncComponent(() => import('@/Navigations/Menu/MenuDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Navigations/Menu/MenuDocs.vue')),
             },
             {
                 name:      'ModalDocs',
-                component: defineAsyncComponent(() => import('@/Overlays/Modal/ModalDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Overlays/Modal/ModalDocs.vue')),
             },
             {
                 name:      'NavbarDocs',
-                component: defineAsyncComponent(() => import('@/Navigations/Navbar/NavbarDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Navigations/Navbar/NavbarDocs.vue')),
             },
             {
                 name:      'PaginationDocs',
-                component: defineAsyncComponent(() => import('@/Navigations/Pagination/PaginationDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Navigations/Pagination/PaginationDocs.vue')),
             },
             {
                 name:      'PopoverDocs',
-                component: defineAsyncComponent(() => import('@/Overlays/Popover/PopoverDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Overlays/Popover/PopoverDocs.vue')),
             },
             {
                 name:      'RadioDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Radio/RadioDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Radio/RadioDocs.vue')),
             },
             {
                 name:      'RangeDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Range/RangeDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Range/RangeDocs.vue')),
             },
             {
                 name:      'RadialProgressDocs',
-                component: defineAsyncComponent(() => import('@/Components/RadialProgress/RadialProgressDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/RadialProgress/RadialProgressDocs.vue')),
             },
             {
                 name:      'SkeletonDocs',
-                component: defineAsyncComponent(() => import('@/Components/Skeleton/SkeletonDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Skeleton/SkeletonDocs.vue')),
             },
             {
                 name:      'StatsDocs',
-                component: defineAsyncComponent(() => import('@/Components/Stats/StatsDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Stats/StatsDocs.vue')),
             },
             {
                 name:      'StatusDocs',
-                component: defineAsyncComponent(() => import('@/Components/Status/StatusDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Status/StatusDocs.vue')),
             },
             {
                 name:      'SwapDocs',
-                component: defineAsyncComponent(() => import('@/Components/Swap/SwapDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Components/Swap/SwapDocs.vue')),
             },
             {
                 name:      'SelectDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Select/SelectDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Select/SelectDocs.vue')),
             },
             {
                 name:      'SwitchDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Switch/SwitchDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Switch/SwitchDocs.vue')),
             },
             {
                 name:      'TabsDocs',
-                component: defineAsyncComponent(() => import('@/Navigations/Tabs/TabsDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Navigations/Tabs/TabsDocs.vue')),
             },
             {
                 name:      'TableDocs',
-                component: defineAsyncComponent(() => import('@/Tables/Table/TableDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Tables/Table/TableDocs.vue')),
             },
             {
                 name:      'TextareaDocs',
-                component: defineAsyncComponent(() => import('@/Forms/Textarea/TextareaDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Forms/Textarea/TextareaDocs.vue')),
             },
             {
                 name:      'TooltipDocs',
-                component: defineAsyncComponent(() => import('@/Overlays/Tooltip/TooltipDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Overlays/Tooltip/TooltipDocs.vue')),
             },
             {
                 name:      'SelectThemeController',
@@ -211,11 +213,11 @@ export default {
             },
             {
                 name:      'Playground',
-                component: defineAsyncComponent(() => import('@/Playground/Playground.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Playground/Playground.vue')),
             },
             {
                 name:      'BuildSizeVisualizer',
-                component: defineAsyncComponent(() => import('@/Extra/BuildSizeVisualizer/BuildSizeVisualizer.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Extra/BuildSizeVisualizer/BuildSizeVisualizer.vue')),
             },
             {
                 name:      'CodePreview',
@@ -223,17 +225,19 @@ export default {
             },
             {
                 name:      'CreateFlyonUIVueAppDocs',
-                component: defineAsyncComponent(() => import('@/QuickStart/CreateFlyonUIVueApp/CreateFlyonUIVueAppDocs.vue')),
+                component: defineAsyncDocsComponent(() => import('@/QuickStart/CreateFlyonUIVueApp/CreateFlyonUIVueAppDocs.vue')),
             },
             {
                 name:      'ComponentsApi',
-                component: defineAsyncComponent(() => import('@/Api/UI/ComponentsApi.vue')),
+                component: defineAsyncDocsComponent(() => import('@/Api/UI/ComponentsApi.vue')),
             },
             {
                 name:      'FoKeyboard',
                 component: FoKeyboard,
             },
         ]);
+
+        loadIconifyIcons();
     },
 } satisfies Theme;
 
@@ -242,8 +246,133 @@ interface RegistrableComponent {
     component: Component;
 }
 
-function registerDocComponents(app: App, components: RegistrableComponent[]): void {
-    for (const component of components) {
-        app.component(component.name, component.component);
+function registerDocComponents(app: App, registrableComponents: RegistrableComponent[]): void {
+    for (const registrableComponent of registrableComponents) {
+        app.component(registrableComponent.name, registrableComponent.component);
     }
+}
+
+function loadIconifyIcons(): void {
+    loadIcons([
+        'bi:chevron-contract',
+        'bi:chevron-double-left',
+        'bi:chevron-double-right',
+        'bi:chevron-expand',
+        'carbon:data-table',
+        'carbon:insert-page',
+        'carbon:user-avatar',
+        'ep:select',
+        'fluent:color-20-regular',
+        'fluent:shapes-20-regular',
+        'fluent:text-direction-horizontal-ltr-20-regular',
+        'fluent:text-direction-horizontal-rtl-20-regular',
+        'gridicons:domains',
+        'ic:round-link',
+        'ic:sharp-account-circle',
+        'ix:hard-reset',
+        'la:border-style',
+        'line-md:account',
+        'line-md:alert',
+        'line-md:loading-twotone-loop',
+        'mdi:account-child',
+        'mdi:account-plus',
+        'mdi:badge-account-outline',
+        'mdi:chart-bar',
+        'mdi:chart-pie',
+        'mdi:checkbox-marked',
+        'mdi:chevron-down-box',
+        'mdi:face-mask',
+        'mdi:file-upload',
+        'mdi:form-textbox',
+        'mdi:format-header-1',
+        'mdi:format-list-bulleted',
+        'mdi:gesture-tap-button',
+        'mdi:keyboard-outline',
+        'mdi:menu',
+        'mdi:radio-button-checked',
+        'mdi:swap-horizontal',
+        'mdi:tab',
+        'mdi:table',
+        'mdi:textarea',
+        'mdi:toggle-switch',
+        'mdi:tooltip-outline',
+        'mdi:tooltip-text',
+        'mdi:view-sequential',
+        'quill:label',
+        'radix-icons:dimensions',
+        'radix-icons:slider',
+        'solar:user-bold',
+        'svg-spinners:3-dots-move',
+        'tabler:alert-triangle',
+        'tabler:apps',
+        'tabler:book',
+        'tabler:books',
+        'tabler:brand-mailgun',
+        'tabler:brand-mastercard',
+        'tabler:calendar',
+        'tabler:calendar-event',
+        'tabler:caret-down-filled',
+        'tabler:caret-left-filled',
+        'tabler:caret-right-filled',
+        'tabler:caret-up-filled',
+        'tabler:cash',
+        'tabler:check',
+        'tabler:layout-sidebar-left-collapse-filled',
+        'tabler:layout-sidebar-right-collapse-filled',
+        'tabler:chevron-down',
+        'tabler:chevron-left',
+        'tabler:chevron-right',
+        'tabler:chevron-up',
+        'tabler:circle-check',
+        'tabler:circle-dot',
+        'tabler:circle-minus',
+        'tabler:circle-plus',
+        'tabler:clock',
+        'tabler:cloud',
+        'tabler:copy',
+        'tabler:copy-check',
+        'tabler:credit-card',
+        'tabler:crown',
+        'tabler:current-location',
+        'tabler:device-desktop',
+        'tabler:device-laptop',
+        'tabler:device-mobile',
+        'tabler:device-tablet',
+        'tabler:dots',
+        'tabler:dots-vertical',
+        'tabler:folder',
+        'tabler:git-compare',
+        'tabler:headphones',
+        'tabler:home',
+        'tabler:info-circle',
+        'tabler:list-details',
+        'tabler:lock',
+        'tabler:mail',
+        'tabler:menu-2',
+        'tabler:message',
+        'tabler:moon',
+        'tabler:movie',
+        'tabler:package',
+        'tabler:pencil',
+        'tabler:player-pause',
+        'tabler:player-play',
+        'tabler:progress',
+        'tabler:quote',
+        'tabler:rocket',
+        'tabler:send',
+        'tabler:separator-horizontal',
+        'tabler:settings',
+        'tabler:settings-bolt',
+        'tabler:star',
+        'tabler:sun',
+        'tabler:trash',
+        'tabler:user',
+        'tabler:users-group',
+        'tabler:volume',
+        'tabler:volume-off',
+        'tabler:world',
+        'tabler:x',
+        'tdesign:placeholder-filled',
+        'uil:icons',
+    ]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added a suspense-driven layout with a centered loading spinner for smoother page transitions.
  * Introduced robust async-component tracking to ensure docs content displays only when fully ready.
  * Simplified navbar/sidebar initialization to reduce unnecessary work and improve startup performance.
* **Bug Fixes**
  * Adjusted sidebar scroll behavior and restored hash-based scrolling after async loads for more reliable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->