### PR TITLE
feat(docs): Show component preview if different view size is clicked from code preview

### DIFF
--- a/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
+++ b/packages/docs/.vitepress/theme/Components/Preview/UI/ComponentPreview.vue
@@ -22,6 +22,7 @@
 
                 <ComponentPreviewResizer v-model:size-class="sizeClass"
                                          class="ms-auto"
+                                         @click.prevent="activeTab.id === codeTab.id && (activeTab = previewTab)"
                 />
 
                 <FoButtonGroup v-if="0 in codePreviews"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component preview interaction: clicking the preview resizer when viewing the Code tab now automatically switches to the Preview tab view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->