### PR TITLE
fix(docs): Remove horizontal overflow when page is too big

### DIFF
--- a/packages/docs/.vitepress/theme/Components/Layout/UI/SuspensibleLayout.vue
+++ b/packages/docs/.vitepress/theme/Components/Layout/UI/SuspensibleLayout.vue
@@ -10,12 +10,12 @@
             <Home v-else-if="isHomepage()" />
 
             <div v-else
-                 class="flex"
+                 class="flex min-w-0"
             >
                 <Sidebar />
 
                 <div v-show="isDocsPageReady"
-                     class="flex w-full"
+                     class="flex min-w-0 flex-1"
                 >
                     <Content class="VPDoc vp-doc grow m-8 min-w-0" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout rendering and content sizing on documentation pages to prevent overflow and enhance responsive behavior on different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->