### PR TITLE
feat(FoDataList)!: Rename FoDatalist to FoDataList to have pascal case component name

### DIFF
--- a/packages/core/src/Lib/UseFlyonUIVueAppConfig/Types/ComponentName.ts
+++ b/packages/core/src/Lib/UseFlyonUIVueAppConfig/Types/ComponentName.ts
@@ -3,7 +3,7 @@ import type { ConfigurableComponentProps } from '@/Lib';
 type NonConfigurableComponentName = 'FoAvatarGroup'
     | 'FoBlockQuote'
     | 'FoCheckboxGroup'
-    | 'FoDatalist'
+    | 'FoDataList'
     | 'FoDataTable'
     | 'FoDiff'
     | 'FoDotStyleBadge'

--- a/packages/core/src/UI/Forms/Select/Types/Select.ts
+++ b/packages/core/src/UI/Forms/Select/Types/Select.ts
@@ -45,11 +45,11 @@ export type SelectProps<
     & WithConfigurableInputLabel
     & WithIcon;
 
-export type DatalistOption<T extends number | string> = Omit<SelectOption<T>, 'disabled'>;
+export type DataListOption<T extends number | string> = Omit<SelectOption<T>, 'disabled'>;
 
-export type DatalistProps<
+export type DataListProps<
     T extends string | number = number,
-    K extends DatalistOption<T> = DatalistOption<T>,
+    K extends DataListOption<T> = DataListOption<T>,
 > = BaseSelectProps<T, K, K>
     & WithPlaceholder
     & WithLabel;

--- a/packages/core/src/UI/Forms/Select/UI/FoDataList.vue
+++ b/packages/core/src/UI/Forms/Select/UI/FoDataList.vue
@@ -23,14 +23,14 @@
 </template>
 
 <script setup lang="ts" generic="T extends string | number, K extends SelectOption<T>">
-import type { DatalistProps, SelectOption } from '@/UI/Forms';
+import type { DataListProps, SelectOption } from '@/UI/Forms';
 import { useElementId }                     from '@/Lib/UseIdentifiable/Internal';
 import { FoLabel }                          from '@/UI/Components/Label/Internal';
 import { FoInputText }                      from '@/UI/Forms';
 import { FoSelectOption, onEmptyOptions }   from '@/UI/Forms/Select/Internal';
 import { computed }                         from 'vue';
 
-const props = withDefaults(defineProps<DatalistProps<T, K>>(), {
+const props = withDefaults(defineProps<DataListProps<T, K>>(), {
     disabled: undefined,
     isValid:  undefined,
 });

--- a/packages/core/src/UI/Forms/Select/UI/index.ts
+++ b/packages/core/src/UI/Forms/Select/UI/index.ts
@@ -1,3 +1,3 @@
-export { default as FoDatalist } from '@/UI/Forms/Select/UI/FoDatalist.vue';
+export { default as FoDataList } from '@/UI/Forms/Select/UI/FoDataList.vue';
 export { default as FoMultipleSelect } from '@/UI/Forms/Select/UI/FoMultipleSelect.vue';
 export { default as FoSelect } from '@/UI/Forms/Select/UI/FoSelect.vue';

--- a/packages/docs/Forms/Select.md
+++ b/packages/docs/Forms/Select.md
@@ -44,7 +44,7 @@
 
 <SelectDocs section="disabled" />
 
-### Datalist
+### Data List
 
 When the input field is empty the selected option will automatically be null.
 

--- a/packages/docs/Forms/Select/SelectAsDataList.vue
+++ b/packages/docs/Forms/Select/SelectAsDataList.vue
@@ -1,5 +1,5 @@
 <template>
-    <FoDatalist v-model="selectedOption"
+    <FoDataList v-model="selectedOption"
                 class="max-w-sm"
                 label="Select your city"
                 placeholder="Type to search..."
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import type { SelectOption }             from 'flyonui-vue';
-import { FoDatalist, useSelectedOption } from 'flyonui-vue';
+import { FoDataList, useSelectedOption } from 'flyonui-vue';
 import { ref }                           from 'vue';
 
 const options = ref<SelectOption[]>([

--- a/packages/docs/Forms/Select/SelectDocs.vue
+++ b/packages/docs/Forms/Select/SelectDocs.vue
@@ -1,7 +1,7 @@
 <template>
     <ComponentDocs :previews="previews"
                    :section="section"
-                   :api-docs-component-names="['FoSelect', 'FoMultipleSelect', 'FoDatalist']"
+                   :api-docs-component-names="['FoSelect', 'FoMultipleSelect', 'FoDataList']"
     />
 </template>
 
@@ -18,8 +18,8 @@ import DisabledSelect                  from '@/Forms/Select/DisabledSelect.vue';
 import DisabledSelectRaw               from '@/Forms/Select/DisabledSelect.vue?raw';
 import MultipleSelect                  from '@/Forms/Select/MultipleSelect.vue';
 import MultipleSelectRaw               from '@/Forms/Select/MultipleSelect.vue?raw';
-import SelectAsDatalist                from '@/Forms/Select/SelectAsDatalist.vue';
-import SelectAsDatalistRaw             from '@/Forms/Select/SelectAsDatalist.vue?raw';
+import SelectAsDataList                from '@/Forms/Select/SelectAsDataList.vue';
+import SelectAsDataListRaw             from '@/Forms/Select/SelectAsDataList.vue?raw';
 import SelectFloatingLabel             from '@/Forms/Select/SelectFloatingLabel.vue';
 import SelectFloatingLabelRaw          from '@/Forms/Select/SelectFloatingLabel.vue?raw';
 import SelectFloatingLabelSize         from '@/Forms/Select/SelectFloatingLabelSize.vue';
@@ -145,8 +145,8 @@ const previews = computed(() => {
         [
             'datalist',
             {
-                code:      SelectAsDatalistRaw,
-                component: SelectAsDatalist,
+                code:      SelectAsDataListRaw,
+                component: SelectAsDataList,
             },
         ],
         [

--- a/packages/docs/UpgradeGuide.md
+++ b/packages/docs/UpgradeGuide.md
@@ -21,7 +21,7 @@ The minimum required version for Node.js is now `>= 20.19.0`.
   `disabled`|`readonly`.
 
 ### FoCheckbox | FoSwitch - defineModel and props
-- The `isIndeterminate` v-model prop as been renamed to `indeterminate`
+- The `isIndeterminate` v-model prop as been renamed to `indeterminate`.
 
 ### FoInputText
 
@@ -45,3 +45,7 @@ The possible values of the prop `social` have been updated and fully lowercased,
 The default color is now the color defined by the flyonui vue configuration, that is neutral if no settings have been
 manually configured. Before, the default color was the `--color-base-content`, if you now want this color you have to pass
 the `base` value to the `color` prop.
+
+### FoDataList
+- The component has been renamed from `FoDatalist` to `FoDataList`.
+- All the types having `Datalist*` in the name have been renamed to `DataList*`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the data list component from `FoDatalist` to `FoDataList` for improved naming consistency across the library.
  * Updated all related type exports for consistency: `DatalistOption` → `DataListOption` and `DatalistProps` → `DataListProps`.
  * Updated documentation, code examples, and the upgrade guide to reflect the new component and type names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->